### PR TITLE
TEAMNADO-2875 add text search

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,3 +8,4 @@ globals:
 rules:
   react/prop-types: 'off'
   react/jsx-key: [2, { checkFragmentShorthand: true }]
+  '@typescript-eslint/ban-ts-comment': 0

--- a/src/components/ProductsTable/ProductsTable.tsx
+++ b/src/components/ProductsTable/ProductsTable.tsx
@@ -1,7 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
 import { TableComposable, Thead, Tr, Th, Tbody, Td, ThProps } from '@patternfly/react-table';
-import { v4 as uuid } from 'uuid';
-import Unavailable from '@redhat-cloud-services/frontend-components/Unavailable';
 import {
   Flex,
   FlexItem,
@@ -12,15 +10,18 @@ import {
   TextContent,
   TextVariants
 } from '@patternfly/react-core';
-import { Processing } from '../../components/emptyState';
-import useProducts, { Product } from '../../hooks/useProducts';
+import { Product } from '../../hooks/useProducts';
 
-const ProductsTable: FunctionComponent = () => {
+interface ProductsTableProps {
+  data: Product[] | undefined;
+  isFetching: boolean;
+}
+
+const ProductsTable: FunctionComponent<ProductsTableProps> = ({ data, isFetching }) => {
   const columnNames = { name: 'Name', quantity: 'Quantity' };
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
   const [searchValue, setSearchValue] = useState('');
-  const { isFetching, isLoading, error, data } = useProducts();
   const [activeSortIndex, setActiveSortIndex] = React.useState<number | null>(null);
   const [activeSortDirection, setActiveSortDirection] = React.useState<'asc' | 'desc' | null>(null);
 
@@ -115,39 +116,42 @@ const ProductsTable: FunctionComponent = () => {
     return products.slice(first, last);
   };
 
-  const Results: FunctionComponent = () => {
-    const sortedProducts = sortProducts(data, activeSortIndex);
-    const searchedProducts = filterDataBySearchTerm(sortedProducts, searchValue);
-    const paginatedProducts = getPage(searchedProducts);
+  const sortedProducts = sortProducts(data, activeSortIndex);
+  const searchedProducts = filterDataBySearchTerm(sortedProducts, searchValue);
+  const paginatedProducts = getPage(searchedProducts);
 
-    return (
-      <>
-        <Flex
-          direction={{ default: 'column', md: 'row' }}
-          justifyContent={{ default: 'justifyContentSpaceBetween' }}
-        >
-          <FlexItem>
-            {data.length > 0 && (
-              <SearchInput
-                placeholder="Filter by Name"
-                value={searchValue}
-                onChange={handleSearch}
-                onClear={clearSearch}
-              />
-            )}
-          </FlexItem>
-          <FlexItem align={{ default: 'alignRight' }}>{pagination()}</FlexItem>
-        </Flex>
-        <TableComposable aria-label="Products" ouiaId={uuid()} ouiaSafe={true}>
-          <Thead>
-            <Tr ouiaId={uuid()} ouiaSafe={true}>
-              <Th sort={getSortParams(0)}>{columnNames.name}</Th>
-              <Th sort={getSortParams(1)}>{columnNames.quantity}</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            {paginatedProducts.map((datum, rowIndex) => (
-              <Tr key={rowIndex} ouiaId={uuid()} ouiaSafe={true}>
+  return (
+    <>
+      <Flex
+        direction={{ default: 'column', md: 'row' }}
+        justifyContent={{ default: 'justifyContentSpaceBetween' }}
+      >
+        <FlexItem>
+          {data.length > 0 && (
+            <SearchInput
+              placeholder="Filter by Name"
+              value={searchValue}
+              onChange={handleSearch}
+              onClear={clearSearch}
+            />
+          )}
+        </FlexItem>
+        <FlexItem align={{ default: 'alignRight' }}>{pagination()}</FlexItem>
+      </Flex>
+      {/* @ts-ignore */}
+      <TableComposable aria-label="Products">
+        <Thead>
+          {/* @ts-ignore */}
+          <Tr>
+            <Th sort={getSortParams(0)}>{columnNames.name}</Th>
+            <Th sort={getSortParams(1)}>{columnNames.quantity}</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {paginatedProducts.map((datum, rowIndex) => (
+            <React.Fragment key={rowIndex}>
+              {/* @ts-ignore */}
+              <Tr>
                 <Td dataLabel={columnNames.name}>
                   <TextContent>
                     <Text component={TextVariants.h3}>
@@ -159,21 +163,13 @@ const ProductsTable: FunctionComponent = () => {
                 </Td>
                 <Td dataLabel={columnNames.quantity}>{datum.quantity}</Td>
               </Tr>
-            ))}
-          </Tbody>
-        </TableComposable>
-        {pagination(PaginationVariant.bottom)}
-      </>
-    );
-  };
-
-  if (isLoading && !error) {
-    return <Processing />;
-  } else if (!isLoading && !error) {
-    return <Results />;
-  } else {
-    return <Unavailable />;
-  }
+            </React.Fragment>
+          ))}
+        </Tbody>
+      </TableComposable>
+      {pagination(PaginationVariant.bottom)}
+    </>
+  );
 };
 
-export default ProductsTable;
+export { ProductsTable as default, ProductsTableProps };

--- a/src/components/ProductsTable/ProductsTable.tsx
+++ b/src/components/ProductsTable/ProductsTable.tsx
@@ -87,7 +87,10 @@ const ProductsTable: FunctionComponent<ProductsTableProps> = ({ data, isFetching
 
   const filterDataBySearchTerm = (data: Product[], searchValue: string): Product[] => {
     return data.filter((entry: Product) => {
-      return (entry.name || '').toLowerCase().includes(searchValue.toLowerCase().trim());
+      const searchTerm = searchValue.toLowerCase().trim();
+      const name = (entry.name || '').toLowerCase();
+      const productLine = (entry.productLine || '').toLowerCase();
+      return name.includes(searchTerm) || productLine.includes(searchTerm);
     });
   };
 

--- a/src/components/ProductsTable/ProductsTable.tsx
+++ b/src/components/ProductsTable/ProductsTable.tsx
@@ -74,6 +74,11 @@ const ProductsTable: FunctionComponent = () => {
     setPage(1);
   };
 
+  const handleSearch = (searchValue: string) => {
+    setSearchValue(searchValue);
+    setPage(1);
+  };
+
   const clearSearch = () => {
     setSearchValue('');
     setPage(1);
@@ -88,11 +93,6 @@ const ProductsTable: FunctionComponent = () => {
   const countProducts = (data: Product[], searchValue: string): number => {
     const filteredData = filterDataBySearchTerm(data, searchValue);
     return filteredData.length;
-  };
-
-  const handleSearch = (searchValue: string) => {
-    setSearchValue(searchValue);
-    setPage(1);
   };
 
   const pagination = (variant = PaginationVariant.top) => {
@@ -129,7 +129,7 @@ const ProductsTable: FunctionComponent = () => {
           <FlexItem>
             {data.length > 0 && (
               <SearchInput
-                placeholder="Filter by name, version or UUID"
+                placeholder="Filter by Name"
                 value={searchValue}
                 onChange={handleSearch}
                 onClear={clearSearch}

--- a/src/components/ProductsTable/ProductsTable.tsx
+++ b/src/components/ProductsTable/ProductsTable.tsx
@@ -22,8 +22,8 @@ const ProductsTable: FunctionComponent<ProductsTableProps> = ({ data, isFetching
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
   const [searchValue, setSearchValue] = useState('');
-  const [activeSortIndex, setActiveSortIndex] = React.useState<number | null>(null);
-  const [activeSortDirection, setActiveSortDirection] = React.useState<'asc' | 'desc' | null>(null);
+  const [activeSortIndex, setActiveSortIndex] = React.useState<number>(0);
+  const [activeSortDirection, setActiveSortDirection] = React.useState<'asc' | 'desc'>('asc');
 
   const getSortableRowValues = (product: Product): (string | number)[] => {
     const { name, quantity } = product;
@@ -44,24 +44,16 @@ const ProductsTable: FunctionComponent<ProductsTableProps> = ({ data, isFetching
   });
 
   const sortProducts = (products: Product[], sortIndex: number) => {
-    if (sortIndex == null) return products;
-
     const sortedProducts = products.sort((a: any, b: any) => {
-      const aValue = getSortableRowValues(a)[sortIndex];
-      const bValue = getSortableRowValues(b)[sortIndex];
-      if (typeof aValue === 'number') {
-        // Numeric sort
-        if (activeSortDirection === 'asc') {
-          return (aValue as number) - (bValue as number);
-        }
-        return (bValue as number) - (aValue as number);
-      } else {
-        // String sort
-        if (activeSortDirection === 'asc') {
-          return (aValue as string).localeCompare(bValue as string);
-        }
-        return (bValue as string).localeCompare(aValue as string);
+      const aValue = getSortableRowValues(a)[sortIndex] || '';
+      const bValue = getSortableRowValues(b)[sortIndex] || '';
+      let result = 0;
+      if (aValue < bValue) {
+        result = -1;
+      } else if (aValue > bValue) {
+        result = 1;
       }
+      return activeSortDirection == 'asc' ? result : -1 * result;
     });
     return sortedProducts;
   };

--- a/src/components/ProductsTable/__tests__/ProductsTable.test.tsx
+++ b/src/components/ProductsTable/__tests__/ProductsTable.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { render, screen, fireEvent } from '@testing-library/react';
-import ProductsTable from '../ProductsTable';
+import ProductsTable, { ProductsTableProps } from '../ProductsTable';
 import useProducts from '../../../hooks/useProducts';
 import { get, def } from 'bdd-lazy-var';
 import factories from '../../../utilities/factories';
@@ -13,49 +13,22 @@ jest.mock('uuid', () => {
 
 const queryClient = new QueryClient();
 
-const Table = () => (
+const Table: FunctionComponent<ProductsTableProps> = ({ data, isFetching }) => (
   <QueryClientProvider client={queryClient}>
-    <ProductsTable />
+    <ProductsTable data={data} isFetching={isFetching} />
   </QueryClientProvider>
 );
 
 describe('ProductsTable', () => {
   def('loading', () => false);
   def('error', () => false);
+  def('fetching', () => false);
   def('data', () => [factories.product.build({ name: 'A', productLine: 'letters', quantity: 3 })]);
 
-  beforeEach(() => {
-    (useProducts as jest.Mock).mockReturnValue({
-      isLoading: get('loading'),
-      error: get('error'),
-      data: get('data')
-    });
-  });
-
   it('renders correctly', () => {
-    const { container } = render(<Table />);
+    const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
 
     expect(container).toMatchSnapshot();
-  });
-
-  describe('when loading', () => {
-    def('loading', () => true);
-
-    it('renders the loading state', () => {
-      const { container } = render(<Table />);
-
-      expect(container).toMatchSnapshot();
-    });
-  });
-
-  describe('when there is an error', () => {
-    def('error', () => true);
-
-    it('renders the error state', () => {
-      const { container } = render(<Table />);
-
-      expect(container).toMatchSnapshot();
-    });
   });
 
   describe('when row column headings are clicked', () => {
@@ -66,14 +39,14 @@ describe('ProductsTable', () => {
     ]);
 
     it('can sort by name', () => {
-      const { container } = render(<Table />);
+      const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
 
       fireEvent.click(screen.getByText('Name'));
       expect(container).toMatchSnapshot();
     });
 
     it('can sort by name, reversed', () => {
-      const { container } = render(<Table />);
+      const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
 
       fireEvent.click(screen.getByText('Name'));
       fireEvent.click(screen.getByText('Name'));
@@ -81,14 +54,14 @@ describe('ProductsTable', () => {
     });
 
     it('can sort by quantity', () => {
-      const { container } = render(<Table />);
+      const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
 
       fireEvent.click(screen.getByText('Quantity'));
       expect(container).toMatchSnapshot();
     });
 
     it('can sort by quantity, reversed', () => {
-      const { container } = render(<Table />);
+      const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
 
       fireEvent.click(screen.getByText('Quantity'));
       fireEvent.click(screen.getByText('Quantity'));
@@ -103,7 +76,7 @@ describe('ProductsTable', () => {
     ]);
 
     it('can change page', () => {
-      const { container } = render(<Table />);
+      const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
 
       const nextPage = screen.getAllByLabelText('Go to next page')[0];
       fireEvent.click(nextPage);
@@ -111,7 +84,7 @@ describe('ProductsTable', () => {
     });
 
     it('can change per page', () => {
-      const { container } = render(<Table />);
+      const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
 
       const perPageArrow = screen.getAllByLabelText('Items per page')[0];
       fireEvent.click(perPageArrow);

--- a/src/components/ProductsTable/__tests__/ProductsTable.test.tsx
+++ b/src/components/ProductsTable/__tests__/ProductsTable.test.tsx
@@ -2,14 +2,8 @@ import React, { FunctionComponent } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { render, screen, fireEvent } from '@testing-library/react';
 import ProductsTable, { ProductsTableProps } from '../ProductsTable';
-import useProducts from '../../../hooks/useProducts';
 import { get, def } from 'bdd-lazy-var';
 import factories from '../../../utilities/factories';
-
-jest.mock('../../../hooks/useProducts');
-jest.mock('uuid', () => {
-  return { v4: jest.fn(() => '00000000-0000-0000-0000-000000000000') };
-});
 
 const queryClient = new QueryClient();
 
@@ -96,16 +90,25 @@ describe('ProductsTable', () => {
 
   describe('when the search is used', () => {
     def('data', () => [
-      factories.product.build({ name: 'Z', quantity: 2, productLine: 'letters' }),
-      factories.product.build({ name: 'A', quantity: 1, productLine: 'letters' }),
+      factories.product.build({ name: 'Z', quantity: 2, productLine: 'consonants' }),
+      factories.product.build({ name: 'A', quantity: 1, productLine: 'vowels' }),
+      factories.product.build({ name: 'P', quantity: 1, productLine: 'consonants' }),
       factories.product.build({ name: undefined, quantity: 0, productLine: undefined })
     ]);
 
-    it('refines the results', () => {
+    it('refines the results by name', () => {
       const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
 
       const input = screen.getByPlaceholderText('Filter by Name');
       fireEvent.change(input, { target: { value: 'Z' } });
+      expect(container).toMatchSnapshot();
+    });
+
+    it('refines the results by product line', () => {
+      const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
+
+      const input = screen.getByPlaceholderText('Filter by Name');
+      fireEvent.change(input, { target: { value: 'vowels' } });
       expect(container).toMatchSnapshot();
     });
 

--- a/src/components/ProductsTable/__tests__/ProductsTable.test.tsx
+++ b/src/components/ProductsTable/__tests__/ProductsTable.test.tsx
@@ -93,4 +93,30 @@ describe('ProductsTable', () => {
       expect(container).toMatchSnapshot();
     });
   });
+
+  describe('when the search is used', () => {
+    def('data', () => [
+      factories.product.build({ name: 'Z', quantity: 2, productLine: 'letters' }),
+      factories.product.build({ name: 'A', quantity: 1, productLine: 'letters' }),
+      factories.product.build({ name: undefined, quantity: 0, productLine: undefined })
+    ]);
+
+    it('refines the results', () => {
+      const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
+
+      const input = screen.getByPlaceholderText('Filter by Name');
+      fireEvent.change(input, { target: { value: 'Z' } });
+      expect(container).toMatchSnapshot();
+    });
+
+    it('can be cleared', () => {
+      const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
+
+      const input = screen.getByPlaceholderText('Filter by Name');
+      fireEvent.change(input, { target: { value: 'Z' } });
+      const clear = screen.getByLabelText('Reset');
+      fireEvent.click(clear);
+      expect(container).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/ProductsTable/__tests__/ProductsTable.test.tsx
+++ b/src/components/ProductsTable/__tests__/ProductsTable.test.tsx
@@ -28,21 +28,20 @@ describe('ProductsTable', () => {
   describe('when row column headings are clicked', () => {
     def('data', () => [
       factories.product.build({ name: 'Z', quantity: 1, productLine: 'letters' }),
-      factories.product.build({ name: 'A', quantity: 3, productLine: 'letters' }),
-      factories.product.build({ name: 'B', quantity: 2, productLine: 'letters' })
+      factories.product.build({ name: undefined, quantity: undefined, productLine: null }),
+      factories.product.build({ name: 'A', quantity: 3, productLine: 'vowels' }),
+      factories.product.build({ name: null, quantity: 2, productLine: 'consonants' })
     ]);
 
-    it('can sort by name', () => {
+    it('sorts by name by default', () => {
       const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
 
-      fireEvent.click(screen.getByText('Name'));
       expect(container).toMatchSnapshot();
     });
 
     it('can sort by name, reversed', () => {
       const { container } = render(<Table data={get('data')} isFetching={get('fetching')} />);
 
-      fireEvent.click(screen.getByText('Name'));
       fireEvent.click(screen.getByText('Name'));
       expect(container).toMatchSnapshot();
     });

--- a/src/components/ProductsTable/__tests__/__snapshots__/ProductsTable.test.tsx.snap
+++ b/src/components/ProductsTable/__tests__/__snapshots__/ProductsTable.test.tsx.snap
@@ -3448,6 +3448,1363 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
 </div>
 `;
 
+exports[`ProductsTable when the search is used can be cleared 1`] = `
+<div>
+  <div
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
+  >
+    <div
+      class=""
+    >
+      <div
+        class="pf-c-search-input"
+      >
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-9"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-38"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
+        >
+          <b>
+            1
+             - 
+            3
+          </b>
+           
+          of
+           
+          <b>
+            3
+          </b>
+           
+          
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
+          data-ouia-safe="true"
+        >
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+          >
+            <span
+              class="pf-c-options-menu__toggle-text"
+            >
+              <b>
+                1
+                 - 
+                3
+              </b>
+               
+              of
+               
+              <b>
+                3
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-17"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-39"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-66"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-67"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-68"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-69"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </div>
+  </div>
+  <table
+    aria-label="Products"
+    class="pf-c-table pf-m-grid-md"
+    data-ouia-component-id="OUIA-Generated-Table-9"
+    data-ouia-component-type="PF4/Table"
+    data-ouia-safe="true"
+    role="grid"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-46"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <th
+          aria-sort="none"
+          class="pf-c-table__sort"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Name
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+        <th
+          aria-sort="none"
+          class="pf-c-table__sort"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Quantity
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+      role="rowgroup"
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-47"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-75"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Z
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-76"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          2
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-50"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-81"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              A
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-82"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-51"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-83"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-84"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              />
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          0
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div
+    class="pf-c-pagination pf-m-bottom"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-9"
+    data-ouia-component-type="PF4/Pagination"
+    data-ouia-safe="true"
+    id="pagination-options-menu-39"
+    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+  >
+    <div
+      class="pf-c-options-menu pf-m-top"
+      data-ouia-component-type="PF4/PaginationOptionsMenu"
+      data-ouia-safe="true"
+    >
+      <div
+        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+      >
+        <span
+          class="pf-c-options-menu__toggle-text"
+        >
+          <b>
+            1
+             - 
+            3
+          </b>
+           
+          of
+           
+          <b>
+            3
+          </b>
+           
+          
+        </span>
+        <button
+          aria-expanded="false"
+          aria-label="Items per page"
+          class="  pf-c-options-menu__toggle-button"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-18"
+          data-ouia-component-type="PF4/DropdownToggle"
+          data-ouia-safe="true"
+          id="pagination-options-menu-toggle-40"
+          type="button"
+        >
+          <span
+            class="pf-c-options-menu__toggle-button-icon"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <nav
+      aria-label="Pagination"
+      class="pf-c-pagination__nav"
+    >
+      <div
+        class="pf-c-pagination__nav-control pf-m-first"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to first page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="first"
+          data-ouia-component-id="OUIA-Generated-Button-plain-70"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to previous page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="previous"
+          data-ouia-component-id="OUIA-Generated-Button-plain-71"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-page-select"
+      >
+        <input
+          aria-label="Current page"
+          class="pf-c-form-control"
+          disabled=""
+          max="1"
+          min="1"
+          type="number"
+          value="1"
+        />
+        <span
+          aria-hidden="true"
+        >
+          of
+           
+          1
+        </span>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to next page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="next"
+          data-ouia-component-id="OUIA-Generated-Button-plain-72"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control pf-m-last"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to last page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="last"
+          data-ouia-component-id="OUIA-Generated-Button-plain-73"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
+        </button>
+      </div>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`ProductsTable when the search is used refines the results 1`] = `
+<div>
+  <div
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
+  >
+    <div
+      class=""
+    >
+      <div
+        class="pf-c-search-input"
+      >
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value="Z"
+              />
+            </span>
+            <span
+              class="pf-c-search-input__utilities"
+            >
+              <span
+                class="pf-c-search-input__clear"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Reset"
+                  class="pf-c-button pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-65"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 352 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-8"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-32"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
+        >
+          <b>
+            1
+             - 
+            1
+          </b>
+           
+          of
+           
+          <b>
+            1
+          </b>
+           
+          
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
+          data-ouia-safe="true"
+        >
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+          >
+            <span
+              class="pf-c-options-menu__toggle-text"
+            >
+              <b>
+                1
+                 - 
+                1
+              </b>
+               
+              of
+               
+              <b>
+                1
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-15"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-33"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-57"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-58"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-59"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-60"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </div>
+  </div>
+  <table
+    aria-label="Products"
+    class="pf-c-table pf-m-grid-md"
+    data-ouia-component-id="OUIA-Generated-Table-8"
+    data-ouia-component-type="PF4/Table"
+    data-ouia-safe="true"
+    role="grid"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-42"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <th
+          aria-sort="none"
+          class="pf-c-table__sort"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Name
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+        <th
+          aria-sort="none"
+          class="pf-c-table__sort"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Quantity
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+      role="rowgroup"
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-43"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-69"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Z
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-70"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          2
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div
+    class="pf-c-pagination pf-m-bottom"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-8"
+    data-ouia-component-type="PF4/Pagination"
+    data-ouia-safe="true"
+    id="pagination-options-menu-33"
+    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+  >
+    <div
+      class="pf-c-options-menu pf-m-top"
+      data-ouia-component-type="PF4/PaginationOptionsMenu"
+      data-ouia-safe="true"
+    >
+      <div
+        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+      >
+        <span
+          class="pf-c-options-menu__toggle-text"
+        >
+          <b>
+            1
+             - 
+            1
+          </b>
+           
+          of
+           
+          <b>
+            1
+          </b>
+           
+          
+        </span>
+        <button
+          aria-expanded="false"
+          aria-label="Items per page"
+          class="  pf-c-options-menu__toggle-button"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-16"
+          data-ouia-component-type="PF4/DropdownToggle"
+          data-ouia-safe="true"
+          id="pagination-options-menu-toggle-34"
+          type="button"
+        >
+          <span
+            class="pf-c-options-menu__toggle-button-icon"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <nav
+      aria-label="Pagination"
+      class="pf-c-pagination__nav"
+    >
+      <div
+        class="pf-c-pagination__nav-control pf-m-first"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to first page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="first"
+          data-ouia-component-id="OUIA-Generated-Button-plain-61"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to previous page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="previous"
+          data-ouia-component-id="OUIA-Generated-Button-plain-62"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-page-select"
+      >
+        <input
+          aria-label="Current page"
+          class="pf-c-form-control"
+          disabled=""
+          max="1"
+          min="1"
+          type="number"
+          value="1"
+        />
+        <span
+          aria-hidden="true"
+        >
+          of
+           
+          1
+        </span>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to next page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="next"
+          data-ouia-component-id="OUIA-Generated-Button-plain-63"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control pf-m-last"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to last page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="last"
+          data-ouia-component-id="OUIA-Generated-Button-plain-64"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
+        </button>
+      </div>
+    </nav>
+  </div>
+</div>
+`;
+
 exports[`ProductsTable when using pagination can change page 1`] = `
 <div>
   <div

--- a/src/components/ProductsTable/__tests__/__snapshots__/ProductsTable.test.tsx.snap
+++ b/src/components/ProductsTable/__tests__/__snapshots__/ProductsTable.test.tsx.snap
@@ -3,40 +3,65 @@
 exports[`ProductsTable renders correctly 1`] = `
 <div>
   <div
-    class="pf-c-pagination"
-    data-ouia-component-id="OUIA-Generated-Pagination-top-1"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-0"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
   >
     <div
-      class="pf-c-pagination__total-items"
-    >
-      <b>
-        1
-         - 
-        1
-      </b>
-       
-      of
-       
-      <b>
-        1
-      </b>
-       
-      
-    </div>
-    <div
-      class="pf-c-options-menu"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
+      class=""
     >
       <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+        class="pf-c-search-input"
       >
-        <span
-          class="pf-c-options-menu__toggle-text"
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-1"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-0"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
         >
           <b>
             1
@@ -51,183 +76,210 @@ exports[`ProductsTable renders correctly 1`] = `
           </b>
            
           
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
-          data-ouia-component-type="PF4/DropdownToggle"
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-0"
-          type="button"
         >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
           >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
+            <span
+              class="pf-c-options-menu__toggle-text"
             >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
+              <b>
+                1
+                 - 
+                1
+              </b>
+               
+              of
+               
+              <b>
+                1
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-0"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-1"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-3"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-4"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
       </div>
     </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-1"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-2"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          disabled=""
-          max="1"
-          min="1"
-          type="number"
-          value="1"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          1
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-3"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-4"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
   </div>
   <table
     aria-label="Products"
     class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+    data-ouia-component-id="OUIA-Generated-Table-1"
     data-ouia-component-type="PF4/Table"
     data-ouia-safe="true"
     role="grid"
@@ -237,7 +289,7 @@ exports[`ProductsTable renders correctly 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-1"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -323,7 +375,7 @@ exports[`ProductsTable renders correctly 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-2"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -572,67 +624,68 @@ exports[`ProductsTable renders correctly 1`] = `
 </div>
 `;
 
-exports[`ProductsTable when loading renders the loading state 1`] = `
-<div>
-  <div
-    class="pf-l-bullseye"
-  >
-    <span
-      aria-valuetext="Loading..."
-      class="pf-c-spinner pf-m-xl"
-      role="progressbar"
-    >
-      <span
-        class="pf-c-spinner__clipper"
-      />
-      <span
-        class="pf-c-spinner__lead-ball"
-      />
-      <span
-        class="pf-c-spinner__tail-ball"
-      />
-    </span>
-  </div>
-</div>
-`;
-
 exports[`ProductsTable when row column headings are clicked can sort by name 1`] = `
 <div>
   <div
-    class="pf-c-pagination"
-    data-ouia-component-id="OUIA-Generated-Pagination-top-3"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-4"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
   >
     <div
-      class="pf-c-pagination__total-items"
-    >
-      <b>
-        1
-         - 
-        3
-      </b>
-       
-      of
-       
-      <b>
-        3
-      </b>
-       
-      
-    </div>
-    <div
-      class="pf-c-options-menu"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
+      class=""
     >
       <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+        class="pf-c-search-input"
       >
-        <span
-          class="pf-c-options-menu__toggle-text"
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-2"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-4"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
         >
           <b>
             1
@@ -647,183 +700,210 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
           </b>
            
           
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
-          data-ouia-component-type="PF4/DropdownToggle"
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-4"
-          type="button"
         >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
           >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
+            <span
+              class="pf-c-options-menu__toggle-text"
             >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
+              <b>
+                1
+                 - 
+                3
+              </b>
+               
+              of
+               
+              <b>
+                3
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-3"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-4"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-9"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-10"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-11"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-12"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
       </div>
     </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-17"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-18"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          disabled=""
-          max="1"
-          min="1"
-          type="number"
-          value="1"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          1
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-19"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-20"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
   </div>
   <table
     aria-label="Products"
     class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+    data-ouia-component-id="OUIA-Generated-Table-2"
     data-ouia-component-type="PF4/Table"
     data-ouia-safe="true"
     role="grid"
@@ -833,7 +913,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-3"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -919,7 +999,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-4"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -932,7 +1012,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-9"
+              data-ouia-component-id="OUIA-Generated-Text-3"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -941,7 +1021,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-10"
+                data-ouia-component-id="OUIA-Generated-Text-4"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -960,7 +1040,713 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-5"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-5"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              B
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-6"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          2
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-6"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-7"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Z
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-8"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div
+    class="pf-c-pagination pf-m-bottom"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-2"
+    data-ouia-component-type="PF4/Pagination"
+    data-ouia-safe="true"
+    id="pagination-options-menu-5"
+    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+  >
+    <div
+      class="pf-c-options-menu pf-m-top"
+      data-ouia-component-type="PF4/PaginationOptionsMenu"
+      data-ouia-safe="true"
+    >
+      <div
+        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+      >
+        <span
+          class="pf-c-options-menu__toggle-text"
+        >
+          <b>
+            1
+             - 
+            3
+          </b>
+           
+          of
+           
+          <b>
+            3
+          </b>
+           
+          
+        </span>
+        <button
+          aria-expanded="false"
+          aria-label="Items per page"
+          class="  pf-c-options-menu__toggle-button"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
+          data-ouia-component-type="PF4/DropdownToggle"
+          data-ouia-safe="true"
+          id="pagination-options-menu-toggle-5"
+          type="button"
+        >
+          <span
+            class="pf-c-options-menu__toggle-button-icon"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <nav
+      aria-label="Pagination"
+      class="pf-c-pagination__nav"
+    >
+      <div
+        class="pf-c-pagination__nav-control pf-m-first"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to first page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="first"
+          data-ouia-component-id="OUIA-Generated-Button-plain-13"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to previous page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="previous"
+          data-ouia-component-id="OUIA-Generated-Button-plain-14"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-page-select"
+      >
+        <input
+          aria-label="Current page"
+          class="pf-c-form-control"
+          disabled=""
+          max="1"
+          min="1"
+          type="number"
+          value="1"
+        />
+        <span
+          aria-hidden="true"
+        >
+          of
+           
+          1
+        </span>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to next page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="next"
+          data-ouia-component-id="OUIA-Generated-Button-plain-15"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control pf-m-last"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to last page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="last"
+          data-ouia-component-id="OUIA-Generated-Button-plain-16"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
+        </button>
+      </div>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`ProductsTable when row column headings are clicked can sort by name, reversed 1`] = `
+<div>
+  <div
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
+  >
+    <div
+      class=""
+    >
+      <div
+        class="pf-c-search-input"
+      >
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-3"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-10"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
+        >
+          <b>
+            1
+             - 
+            3
+          </b>
+           
+          of
+           
+          <b>
+            3
+          </b>
+           
+          
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
+          data-ouia-safe="true"
+        >
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+          >
+            <span
+              class="pf-c-options-menu__toggle-text"
+            >
+              <b>
+                1
+                 - 
+                3
+              </b>
+               
+              of
+               
+              <b>
+                3
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-10"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-17"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-18"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-19"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-20"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </div>
+  </div>
+  <table
+    aria-label="Products"
+    class="pf-c-table pf-m-grid-md"
+    data-ouia-component-id="OUIA-Generated-Table-3"
+    data-ouia-component-type="PF4/Table"
+    data-ouia-safe="true"
+    role="grid"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-7"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <th
+          aria-sort="descending"
+          class="pf-c-table__sort pf-m-selected"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Name
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M168 345.941V44c0-6.627-5.373-12-12-12h-56c-6.627 0-12 5.373-12 12v301.941H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.569 9.373 33.941 0l86.059-86.059c15.119-15.119 4.411-40.971-16.971-40.971H168z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+        <th
+          aria-sort="none"
+          class="pf-c-table__sort"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Quantity
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+      role="rowgroup"
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-8"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-9"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Z
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-10"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-9"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -1001,7 +1787,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-10"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -1019,7 +1805,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
               data-ouia-safe="true"
               data-pf-content="true"
             >
-              Z
+              A
               <br />
               <small
                 class=""
@@ -1037,7 +1823,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
           class=""
           data-label="Quantity"
         >
-          1
+          3
         </td>
       </tr>
     </tbody>
@@ -1047,7 +1833,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
     data-ouia-component-id="OUIA-Generated-Pagination-bottom-3"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
-    id="pagination-options-menu-5"
+    id="pagination-options-menu-11"
     style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
   >
     <div
@@ -1082,7 +1868,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
           data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-5"
+          id="pagination-options-menu-toggle-11"
           type="button"
         >
           <span
@@ -1250,697 +2036,68 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
 </div>
 `;
 
-exports[`ProductsTable when row column headings are clicked can sort by name, reversed 1`] = `
-<div>
-  <div
-    class="pf-c-pagination"
-    data-ouia-component-id="OUIA-Generated-Pagination-top-6"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-10"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-  >
-    <div
-      class="pf-c-pagination__total-items"
-    >
-      <b>
-        1
-         - 
-        3
-      </b>
-       
-      of
-       
-      <b>
-        3
-      </b>
-       
-      
-    </div>
-    <div
-      class="pf-c-options-menu"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
-    >
-      <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-      >
-        <span
-          class="pf-c-options-menu__toggle-text"
-        >
-          <b>
-            1
-             - 
-            3
-          </b>
-           
-          of
-           
-          <b>
-            3
-          </b>
-           
-          
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-11"
-          data-ouia-component-type="PF4/DropdownToggle"
-          data-ouia-safe="true"
-          id="pagination-options-menu-toggle-10"
-          type="button"
-        >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
-            >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-    </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-41"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-42"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          disabled=""
-          max="1"
-          min="1"
-          type="number"
-          value="1"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          1
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-43"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-44"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
-  </div>
-  <table
-    aria-label="Products"
-    class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="00000000-0000-0000-0000-000000000000"
-    data-ouia-component-type="PF4/Table"
-    data-ouia-safe="true"
-    role="grid"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <th
-          aria-sort="descending"
-          class="pf-c-table__sort pf-m-selected"
-          scope="col"
-        >
-          <button
-            class="pf-c-table__button"
-            type="button"
-          >
-            <div
-              class="pf-c-table__button-content"
-            >
-              <span
-                class="pf-c-table__text"
-              >
-                Name
-              </span>
-              <span
-                class="pf-c-table__sort-indicator"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M168 345.941V44c0-6.627-5.373-12-12-12h-56c-6.627 0-12 5.373-12 12v301.941H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.569 9.373 33.941 0l86.059-86.059c15.119-15.119 4.411-40.971-16.971-40.971H168z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </button>
-        </th>
-        <th
-          aria-sort="none"
-          class="pf-c-table__sort"
-          scope="col"
-        >
-          <button
-            class="pf-c-table__button"
-            type="button"
-          >
-            <div
-              class="pf-c-table__button-content"
-            >
-              <span
-                class="pf-c-table__text"
-              >
-                Quantity
-              </span>
-              <span
-                class="pf-c-table__sort-indicator"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </button>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class=""
-      role="rowgroup"
-    >
-      <tr
-        class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-27"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              Z
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-28"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          1
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-29"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              B
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-30"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          2
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-31"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              A
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-32"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          3
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <div
-    class="pf-c-pagination pf-m-bottom"
-    data-ouia-component-id="OUIA-Generated-Pagination-bottom-6"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-11"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-  >
-    <div
-      class="pf-c-options-menu pf-m-top"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
-    >
-      <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-      >
-        <span
-          class="pf-c-options-menu__toggle-text"
-        >
-          <b>
-            1
-             - 
-            3
-          </b>
-           
-          of
-           
-          <b>
-            3
-          </b>
-           
-          
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-12"
-          data-ouia-component-type="PF4/DropdownToggle"
-          data-ouia-safe="true"
-          id="pagination-options-menu-toggle-11"
-          type="button"
-        >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
-            >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-    </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-45"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-46"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          disabled=""
-          max="1"
-          min="1"
-          type="number"
-          value="1"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          1
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-47"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-48"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
-  </div>
-</div>
-`;
-
 exports[`ProductsTable when row column headings are clicked can sort by quantity 1`] = `
 <div>
   <div
-    class="pf-c-pagination"
-    data-ouia-component-id="OUIA-Generated-Pagination-top-8"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-14"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
   >
     <div
-      class="pf-c-pagination__total-items"
-    >
-      <b>
-        1
-         - 
-        3
-      </b>
-       
-      of
-       
-      <b>
-        3
-      </b>
-       
-      
-    </div>
-    <div
-      class="pf-c-options-menu"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
+      class=""
     >
       <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+        class="pf-c-search-input"
       >
-        <span
-          class="pf-c-options-menu__toggle-text"
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-4"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-14"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
         >
           <b>
             1
@@ -1955,183 +2112,210 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           </b>
            
           
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-15"
-          data-ouia-component-type="PF4/DropdownToggle"
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-14"
-          type="button"
         >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
           >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
+            <span
+              class="pf-c-options-menu__toggle-text"
             >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
+              <b>
+                1
+                 - 
+                3
+              </b>
+               
+              of
+               
+              <b>
+                3
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-14"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-25"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-26"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-27"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-28"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
       </div>
     </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-57"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-58"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          disabled=""
-          max="1"
-          min="1"
-          type="number"
-          value="1"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          1
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-59"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-60"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
   </div>
   <table
     aria-label="Products"
     class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+    data-ouia-component-id="OUIA-Generated-Table-4"
     data-ouia-component-type="PF4/Table"
     data-ouia-safe="true"
     role="grid"
@@ -2141,7 +2325,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-11"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -2227,7 +2411,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-12"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -2240,7 +2424,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-39"
+              data-ouia-component-id="OUIA-Generated-Text-15"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -2249,7 +2433,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-40"
+                data-ouia-component-id="OUIA-Generated-Text-16"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -2268,7 +2452,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-13"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -2281,7 +2465,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-41"
+              data-ouia-component-id="OUIA-Generated-Text-17"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -2290,7 +2474,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-42"
+                data-ouia-component-id="OUIA-Generated-Text-18"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -2309,7 +2493,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-14"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -2322,7 +2506,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-43"
+              data-ouia-component-id="OUIA-Generated-Text-19"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -2331,7 +2515,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-44"
+                data-ouia-component-id="OUIA-Generated-Text-20"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -2352,7 +2536,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
   </table>
   <div
     class="pf-c-pagination pf-m-bottom"
-    data-ouia-component-id="OUIA-Generated-Pagination-bottom-8"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-4"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
     id="pagination-options-menu-15"
@@ -2387,7 +2571,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           aria-expanded="false"
           aria-label="Items per page"
           class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-16"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-8"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
           id="pagination-options-menu-toggle-15"
@@ -2425,7 +2609,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           aria-label="Go to first page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-61"
+          data-ouia-component-id="OUIA-Generated-Button-plain-29"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -2454,7 +2638,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           aria-label="Go to previous page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-62"
+          data-ouia-component-id="OUIA-Generated-Button-plain-30"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -2503,7 +2687,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           aria-label="Go to next page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-63"
+          data-ouia-component-id="OUIA-Generated-Button-plain-31"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -2532,7 +2716,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           aria-label="Go to last page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-64"
+          data-ouia-component-id="OUIA-Generated-Button-plain-32"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -2561,40 +2745,65 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
 exports[`ProductsTable when row column headings are clicked can sort by quantity, reversed 1`] = `
 <div>
   <div
-    class="pf-c-pagination"
-    data-ouia-component-id="OUIA-Generated-Pagination-top-11"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-20"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
   >
     <div
-      class="pf-c-pagination__total-items"
-    >
-      <b>
-        1
-         - 
-        3
-      </b>
-       
-      of
-       
-      <b>
-        3
-      </b>
-       
-      
-    </div>
-    <div
-      class="pf-c-options-menu"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
+      class=""
     >
       <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+        class="pf-c-search-input"
       >
-        <span
-          class="pf-c-options-menu__toggle-text"
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-5"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-20"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
         >
           <b>
             1
@@ -2609,183 +2818,210 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           </b>
            
           
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-21"
-          data-ouia-component-type="PF4/DropdownToggle"
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-20"
-          type="button"
         >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
           >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
+            <span
+              class="pf-c-options-menu__toggle-text"
             >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
+              <b>
+                1
+                 - 
+                3
+              </b>
+               
+              of
+               
+              <b>
+                3
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-9"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-20"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-33"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-34"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-35"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-36"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
       </div>
     </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-81"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-82"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          disabled=""
-          max="1"
-          min="1"
-          type="number"
-          value="1"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          1
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-83"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-84"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
   </div>
   <table
     aria-label="Products"
     class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+    data-ouia-component-id="OUIA-Generated-Table-5"
     data-ouia-component-type="PF4/Table"
     data-ouia-safe="true"
     role="grid"
@@ -2795,7 +3031,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-15"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -2881,7 +3117,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-16"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -2894,7 +3130,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-57"
+              data-ouia-component-id="OUIA-Generated-Text-21"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -2903,7 +3139,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-58"
+                data-ouia-component-id="OUIA-Generated-Text-22"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -2922,7 +3158,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-17"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -2935,7 +3171,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-59"
+              data-ouia-component-id="OUIA-Generated-Text-23"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -2944,7 +3180,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-60"
+                data-ouia-component-id="OUIA-Generated-Text-24"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -2963,7 +3199,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-18"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -2976,7 +3212,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-61"
+              data-ouia-component-id="OUIA-Generated-Text-25"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -2985,7 +3221,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-62"
+                data-ouia-component-id="OUIA-Generated-Text-26"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -3006,7 +3242,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
   </table>
   <div
     class="pf-c-pagination pf-m-bottom"
-    data-ouia-component-id="OUIA-Generated-Pagination-bottom-11"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-5"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
     id="pagination-options-menu-21"
@@ -3041,7 +3277,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           aria-expanded="false"
           aria-label="Items per page"
           class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-22"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-10"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
           id="pagination-options-menu-toggle-21"
@@ -3079,7 +3315,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           aria-label="Go to first page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-85"
+          data-ouia-component-id="OUIA-Generated-Button-plain-37"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -3108,7 +3344,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           aria-label="Go to previous page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-86"
+          data-ouia-component-id="OUIA-Generated-Button-plain-38"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -3157,7 +3393,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           aria-label="Go to next page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-87"
+          data-ouia-component-id="OUIA-Generated-Button-plain-39"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -3186,7 +3422,7 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
           aria-label="Go to last page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-88"
+          data-ouia-component-id="OUIA-Generated-Button-plain-40"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -3212,91 +3448,68 @@ exports[`ProductsTable when row column headings are clicked can sort by quantity
 </div>
 `;
 
-exports[`ProductsTable when there is an error renders the error state 1`] = `
-<div>
-  <div
-    class="pf-c-empty-state pf-m-lg ins-c-empty-state__unavailable pf-m-redhat-font"
-  >
-    <div
-      class="pf-c-empty-state__content"
-    >
-      <svg
-        aria-hidden="true"
-        class="pf-c-empty-state__icon"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style="vertical-align: -0.125em;"
-        viewBox="0 0 512 512"
-        width="1em"
-      >
-        <path
-          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-        />
-      </svg>
-      <h5
-        class="pf-c-title pf-m-lg"
-        data-ouia-component-id="OUIA-Generated-Title-1"
-        data-ouia-component-type="PF4/Title"
-        data-ouia-safe="true"
-      >
-        This page is temporarily unavailable
-      </h5>
-      <div
-        class="pf-c-empty-state__body"
-      >
-        Try refreshing the page. If the problem persists, contact your organization administrator or visit our
-        <a
-          href="https://status.redhat.com/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-           status page
-        </a>
-         for known outages.
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`ProductsTable when using pagination can change page 1`] = `
 <div>
   <div
-    class="pf-c-pagination"
-    data-ouia-component-id="OUIA-Generated-Pagination-top-13"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-24"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
   >
     <div
-      class="pf-c-pagination__total-items"
-    >
-      <b>
-        11
-         - 
-        11
-      </b>
-       
-      of
-       
-      <b>
-        11
-      </b>
-       
-      
-    </div>
-    <div
-      class="pf-c-options-menu"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
+      class=""
     >
       <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+        class="pf-c-search-input"
       >
-        <span
-          class="pf-c-options-menu__toggle-text"
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-6"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-24"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
         >
           <b>
             11
@@ -3311,180 +3524,207 @@ exports[`ProductsTable when using pagination can change page 1`] = `
           </b>
            
           
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-25"
-          data-ouia-component-type="PF4/DropdownToggle"
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-24"
-          type="button"
         >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
           >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
+            <span
+              class="pf-c-options-menu__toggle-text"
             >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
+              <b>
+                11
+                 - 
+                11
+              </b>
+               
+              of
+               
+              <b>
+                11
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-11"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-24"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-41"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-42"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              max="2"
+              min="1"
+              type="number"
+              value="2"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              2
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-43"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-44"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
       </div>
     </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="false"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-97"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="false"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-98"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          max="2"
-          min="1"
-          type="number"
-          value="2"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          2
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-99"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-100"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
   </div>
   <table
     aria-label="Products"
     class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+    data-ouia-component-id="OUIA-Generated-Table-6"
     data-ouia-component-type="PF4/Table"
     data-ouia-safe="true"
     role="grid"
@@ -3494,7 +3734,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-19"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -3580,7 +3820,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-20"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -3593,7 +3833,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-83"
+              data-ouia-component-id="OUIA-Generated-Text-27"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -3602,7 +3842,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-84"
+                data-ouia-component-id="OUIA-Generated-Text-28"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -3623,7 +3863,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
   </table>
   <div
     class="pf-c-pagination pf-m-bottom"
-    data-ouia-component-id="OUIA-Generated-Pagination-bottom-13"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-6"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
     id="pagination-options-menu-25"
@@ -3658,7 +3898,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
           aria-expanded="false"
           aria-label="Items per page"
           class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-26"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-12"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
           id="pagination-options-menu-toggle-25"
@@ -3696,7 +3936,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
           aria-label="Go to first page"
           class="pf-c-button pf-m-plain"
           data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-101"
+          data-ouia-component-id="OUIA-Generated-Button-plain-45"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           type="button"
@@ -3724,7 +3964,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
           aria-label="Go to previous page"
           class="pf-c-button pf-m-plain"
           data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-102"
+          data-ouia-component-id="OUIA-Generated-Button-plain-46"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           type="button"
@@ -3771,7 +4011,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
           aria-label="Go to next page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-103"
+          data-ouia-component-id="OUIA-Generated-Button-plain-47"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -3800,7 +4040,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
           aria-label="Go to last page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-104"
+          data-ouia-component-id="OUIA-Generated-Button-plain-48"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -3829,40 +4069,65 @@ exports[`ProductsTable when using pagination can change page 1`] = `
 exports[`ProductsTable when using pagination can change per page 1`] = `
 <div>
   <div
-    class="pf-c-pagination"
-    data-ouia-component-id="OUIA-Generated-Pagination-top-15"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-28"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
   >
     <div
-      class="pf-c-pagination__total-items"
-    >
-      <b>
-        1
-         - 
-        11
-      </b>
-       
-      of
-       
-      <b>
-        11
-      </b>
-       
-      
-    </div>
-    <div
-      class="pf-c-options-menu"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
+      class=""
     >
       <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+        class="pf-c-search-input"
       >
-        <span
-          class="pf-c-options-menu__toggle-text"
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-7"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-28"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
         >
           <b>
             1
@@ -3877,183 +4142,210 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           </b>
            
           
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-29"
-          data-ouia-component-type="PF4/DropdownToggle"
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-29"
-          type="button"
         >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
           >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
+            <span
+              class="pf-c-options-menu__toggle-text"
             >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
+              <b>
+                1
+                 - 
+                11
+              </b>
+               
+              of
+               
+              <b>
+                11
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-29"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-49"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-50"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-51"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-52"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
       </div>
     </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-113"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-114"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          disabled=""
-          max="1"
-          min="1"
-          type="number"
-          value="1"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          1
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-115"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-116"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
   </div>
   <table
     aria-label="Products"
     class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+    data-ouia-component-id="OUIA-Generated-Table-7"
     data-ouia-component-type="PF4/Table"
     data-ouia-safe="true"
     role="grid"
@@ -4063,7 +4355,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-30"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4149,7 +4441,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-31"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4162,7 +4454,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-105"
+              data-ouia-component-id="OUIA-Generated-Text-47"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4171,7 +4463,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-106"
+                data-ouia-component-id="OUIA-Generated-Text-48"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4190,7 +4482,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-32"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4203,7 +4495,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-107"
+              data-ouia-component-id="OUIA-Generated-Text-49"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4212,7 +4504,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-108"
+                data-ouia-component-id="OUIA-Generated-Text-50"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4231,7 +4523,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-33"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4244,7 +4536,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-109"
+              data-ouia-component-id="OUIA-Generated-Text-51"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4253,7 +4545,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-110"
+                data-ouia-component-id="OUIA-Generated-Text-52"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4272,7 +4564,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-34"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4285,7 +4577,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-111"
+              data-ouia-component-id="OUIA-Generated-Text-53"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4294,7 +4586,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-112"
+                data-ouia-component-id="OUIA-Generated-Text-54"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4313,7 +4605,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-35"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4326,7 +4618,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-113"
+              data-ouia-component-id="OUIA-Generated-Text-55"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4335,7 +4627,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-114"
+                data-ouia-component-id="OUIA-Generated-Text-56"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4354,7 +4646,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-36"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4367,7 +4659,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-115"
+              data-ouia-component-id="OUIA-Generated-Text-57"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4376,7 +4668,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-116"
+                data-ouia-component-id="OUIA-Generated-Text-58"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4395,7 +4687,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-37"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4408,7 +4700,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-117"
+              data-ouia-component-id="OUIA-Generated-Text-59"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4417,7 +4709,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-118"
+                data-ouia-component-id="OUIA-Generated-Text-60"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4436,7 +4728,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-38"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4449,7 +4741,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-119"
+              data-ouia-component-id="OUIA-Generated-Text-61"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4458,7 +4750,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-120"
+                data-ouia-component-id="OUIA-Generated-Text-62"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4477,7 +4769,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-39"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4490,7 +4782,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-121"
+              data-ouia-component-id="OUIA-Generated-Text-63"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4499,7 +4791,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-122"
+                data-ouia-component-id="OUIA-Generated-Text-64"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4518,7 +4810,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-40"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4531,7 +4823,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-123"
+              data-ouia-component-id="OUIA-Generated-Text-65"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4540,7 +4832,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-124"
+                data-ouia-component-id="OUIA-Generated-Text-66"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4559,7 +4851,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="00000000-0000-0000-0000-000000000000"
+        data-ouia-component-id="OUIA-Generated-TableRow-41"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4572,7 +4864,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-125"
+              data-ouia-component-id="OUIA-Generated-Text-67"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4581,7 +4873,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-126"
+                data-ouia-component-id="OUIA-Generated-Text-68"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4602,7 +4894,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
   </table>
   <div
     class="pf-c-pagination pf-m-bottom"
-    data-ouia-component-id="OUIA-Generated-Pagination-bottom-15"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-7"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
     id="pagination-options-menu-29"
@@ -4637,7 +4929,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           aria-expanded="false"
           aria-label="Items per page"
           class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-30"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-14"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
           id="pagination-options-menu-toggle-30"
@@ -4675,7 +4967,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           aria-label="Go to first page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-117"
+          data-ouia-component-id="OUIA-Generated-Button-plain-53"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -4704,7 +4996,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           aria-label="Go to previous page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-118"
+          data-ouia-component-id="OUIA-Generated-Button-plain-54"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -4753,7 +5045,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           aria-label="Go to next page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-119"
+          data-ouia-component-id="OUIA-Generated-Button-plain-55"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -4782,7 +5074,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           aria-label="Go to last page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-120"
+          data-ouia-component-id="OUIA-Generated-Button-plain-56"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""

--- a/src/components/ProductsTable/__tests__/__snapshots__/ProductsTable.test.tsx.snap
+++ b/src/components/ProductsTable/__tests__/__snapshots__/ProductsTable.test.tsx.snap
@@ -3502,10 +3502,10 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
     >
       <div
         class="pf-c-pagination"
-        data-ouia-component-id="OUIA-Generated-Pagination-top-9"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-10"
         data-ouia-component-type="PF4/Pagination"
         data-ouia-safe="true"
-        id="pagination-options-menu-38"
+        id="pagination-options-menu-42"
         style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
       >
         <div
@@ -3514,13 +3514,13 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           <b>
             1
              - 
-            3
+            4
           </b>
            
           of
            
           <b>
-            3
+            4
           </b>
            
           
@@ -3539,13 +3539,13 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               <b>
                 1
                  - 
-                3
+                4
               </b>
                
               of
                
               <b>
-                3
+                4
               </b>
                
               
@@ -3554,10 +3554,10 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               aria-expanded="false"
               aria-label="Items per page"
               class="  pf-c-options-menu__toggle-button"
-              data-ouia-component-id="OUIA-Generated-DropdownToggle-17"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-19"
               data-ouia-component-type="PF4/DropdownToggle"
               data-ouia-safe="true"
-              id="pagination-options-menu-toggle-39"
+              id="pagination-options-menu-toggle-43"
               type="button"
             >
               <span
@@ -3592,7 +3592,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               aria-label="Go to first page"
               class="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-66"
+              data-ouia-component-id="OUIA-Generated-Button-plain-75"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe="true"
               disabled=""
@@ -3621,7 +3621,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               aria-label="Go to previous page"
               class="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-67"
+              data-ouia-component-id="OUIA-Generated-Button-plain-76"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe="true"
               disabled=""
@@ -3670,7 +3670,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               aria-label="Go to next page"
               class="pf-c-button pf-m-plain pf-m-disabled"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-68"
+              data-ouia-component-id="OUIA-Generated-Button-plain-77"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe="true"
               disabled=""
@@ -3699,7 +3699,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               aria-label="Go to last page"
               class="pf-c-button pf-m-plain pf-m-disabled"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-69"
+              data-ouia-component-id="OUIA-Generated-Button-plain-78"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe="true"
               disabled=""
@@ -3727,7 +3727,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
   <table
     aria-label="Products"
     class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="OUIA-Generated-Table-9"
+    data-ouia-component-id="OUIA-Generated-Table-10"
     data-ouia-component-type="PF4/Table"
     data-ouia-safe="true"
     role="grid"
@@ -3737,7 +3737,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-46"
+        data-ouia-component-id="OUIA-Generated-TableRow-52"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -3823,7 +3823,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-47"
+        data-ouia-component-id="OUIA-Generated-TableRow-53"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -3836,7 +3836,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-75"
+              data-ouia-component-id="OUIA-Generated-Text-85"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -3845,12 +3845,12 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-76"
+                data-ouia-component-id="OUIA-Generated-Text-86"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
               >
-                letters
+                consonants
               </small>
             </h3>
           </div>
@@ -3864,7 +3864,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-50"
+        data-ouia-component-id="OUIA-Generated-TableRow-57"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -3877,7 +3877,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-81"
+              data-ouia-component-id="OUIA-Generated-Text-93"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -3886,12 +3886,12 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-82"
+                data-ouia-component-id="OUIA-Generated-Text-94"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
               >
-                letters
+                vowels
               </small>
             </h3>
           </div>
@@ -3905,7 +3905,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-51"
+        data-ouia-component-id="OUIA-Generated-TableRow-58"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -3918,7 +3918,48 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-83"
+              data-ouia-component-id="OUIA-Generated-Text-95"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              P
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-96"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                consonants
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-59"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-97"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -3926,7 +3967,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-84"
+                data-ouia-component-id="OUIA-Generated-Text-98"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -3945,10 +3986,10 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
   </table>
   <div
     class="pf-c-pagination pf-m-bottom"
-    data-ouia-component-id="OUIA-Generated-Pagination-bottom-9"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-10"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
-    id="pagination-options-menu-39"
+    id="pagination-options-menu-43"
     style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
   >
     <div
@@ -3965,13 +4006,13 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           <b>
             1
              - 
-            3
+            4
           </b>
            
           of
            
           <b>
-            3
+            4
           </b>
            
           
@@ -3980,10 +4021,10 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           aria-expanded="false"
           aria-label="Items per page"
           class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-18"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-20"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-40"
+          id="pagination-options-menu-toggle-44"
           type="button"
         >
           <span
@@ -4018,7 +4059,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           aria-label="Go to first page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-70"
+          data-ouia-component-id="OUIA-Generated-Button-plain-79"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -4047,7 +4088,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           aria-label="Go to previous page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-71"
+          data-ouia-component-id="OUIA-Generated-Button-plain-80"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -4096,7 +4137,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           aria-label="Go to next page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-72"
+          data-ouia-component-id="OUIA-Generated-Button-plain-81"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -4125,7 +4166,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           aria-label="Go to last page"
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-73"
+          data-ouia-component-id="OUIA-Generated-Button-plain-82"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""
@@ -4151,7 +4192,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
 </div>
 `;
 
-exports[`ProductsTable when the search is used refines the results 1`] = `
+exports[`ProductsTable when the search is used refines the results by name 1`] = `
 <div>
   <div
     class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
@@ -4583,7 +4624,7 @@ exports[`ProductsTable when the search is used refines the results 1`] = `
                 data-ouia-safe="true"
                 data-pf-content="true"
               >
-                letters
+                consonants
               </small>
             </h3>
           </div>
@@ -4780,6 +4821,660 @@ exports[`ProductsTable when the search is used refines the results 1`] = `
           class="pf-c-button pf-m-plain pf-m-disabled"
           data-action="last"
           data-ouia-component-id="OUIA-Generated-Button-plain-64"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
+        </button>
+      </div>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`ProductsTable when the search is used refines the results by product line 1`] = `
+<div>
+  <div
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
+  >
+    <div
+      class=""
+    >
+      <div
+        class="pf-c-search-input"
+      >
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value="vowels"
+              />
+            </span>
+            <span
+              class="pf-c-search-input__utilities"
+            >
+              <span
+                class="pf-c-search-input__clear"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Reset"
+                  class="pf-c-button pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-74"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 352 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-9"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-36"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
+        >
+          <b>
+            1
+             - 
+            1
+          </b>
+           
+          of
+           
+          <b>
+            1
+          </b>
+           
+          
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
+          data-ouia-safe="true"
+        >
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+          >
+            <span
+              class="pf-c-options-menu__toggle-text"
+            >
+              <b>
+                1
+                 - 
+                1
+              </b>
+               
+              of
+               
+              <b>
+                1
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-17"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-37"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-66"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-67"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-68"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-69"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </div>
+  </div>
+  <table
+    aria-label="Products"
+    class="pf-c-table pf-m-grid-md"
+    data-ouia-component-id="OUIA-Generated-Table-9"
+    data-ouia-component-type="PF4/Table"
+    data-ouia-safe="true"
+    role="grid"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-47"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <th
+          aria-sort="none"
+          class="pf-c-table__sort"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Name
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+        <th
+          aria-sort="none"
+          class="pf-c-table__sort"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Quantity
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+      role="rowgroup"
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-48"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-77"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              A
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-78"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                vowels
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div
+    class="pf-c-pagination pf-m-bottom"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-9"
+    data-ouia-component-type="PF4/Pagination"
+    data-ouia-safe="true"
+    id="pagination-options-menu-37"
+    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+  >
+    <div
+      class="pf-c-options-menu pf-m-top"
+      data-ouia-component-type="PF4/PaginationOptionsMenu"
+      data-ouia-safe="true"
+    >
+      <div
+        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+      >
+        <span
+          class="pf-c-options-menu__toggle-text"
+        >
+          <b>
+            1
+             - 
+            1
+          </b>
+           
+          of
+           
+          <b>
+            1
+          </b>
+           
+          
+        </span>
+        <button
+          aria-expanded="false"
+          aria-label="Items per page"
+          class="  pf-c-options-menu__toggle-button"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-18"
+          data-ouia-component-type="PF4/DropdownToggle"
+          data-ouia-safe="true"
+          id="pagination-options-menu-toggle-38"
+          type="button"
+        >
+          <span
+            class="pf-c-options-menu__toggle-button-icon"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <nav
+      aria-label="Pagination"
+      class="pf-c-pagination__nav"
+    >
+      <div
+        class="pf-c-pagination__nav-control pf-m-first"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to first page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="first"
+          data-ouia-component-id="OUIA-Generated-Button-plain-70"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to previous page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="previous"
+          data-ouia-component-id="OUIA-Generated-Button-plain-71"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-page-select"
+      >
+        <input
+          aria-label="Current page"
+          class="pf-c-form-control"
+          disabled=""
+          max="1"
+          min="1"
+          type="number"
+          value="1"
+        />
+        <span
+          aria-hidden="true"
+        >
+          of
+           
+          1
+        </span>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to next page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="next"
+          data-ouia-component-id="OUIA-Generated-Button-plain-72"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control pf-m-last"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to last page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="last"
+          data-ouia-component-id="OUIA-Generated-Button-plain-73"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
           disabled=""

--- a/src/components/ProductsTable/__tests__/__snapshots__/ProductsTable.test.tsx.snap
+++ b/src/components/ProductsTable/__tests__/__snapshots__/ProductsTable.test.tsx.snap
@@ -294,8 +294,8 @@ exports[`ProductsTable renders correctly 1`] = `
         data-ouia-safe="true"
       >
         <th
-          aria-sort="none"
-          class="pf-c-table__sort"
+          aria-sort="ascending"
+          class="pf-c-table__sort pf-m-selected"
           scope="col"
         >
           <button
@@ -323,7 +323,7 @@ exports[`ProductsTable renders correctly 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                    d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
                   />
                 </svg>
               </span>
@@ -624,7 +624,2230 @@ exports[`ProductsTable renders correctly 1`] = `
 </div>
 `;
 
-exports[`ProductsTable when row column headings are clicked can sort by name 1`] = `
+exports[`ProductsTable when row column headings are clicked can sort by name, reversed 1`] = `
+<div>
+  <div
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
+  >
+    <div
+      class=""
+    >
+      <div
+        class="pf-c-search-input"
+      >
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-3"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-6"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
+        >
+          <b>
+            1
+             - 
+            4
+          </b>
+           
+          of
+           
+          <b>
+            4
+          </b>
+           
+          
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
+          data-ouia-safe="true"
+        >
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+          >
+            <span
+              class="pf-c-options-menu__toggle-text"
+            >
+              <b>
+                1
+                 - 
+                4
+              </b>
+               
+              of
+               
+              <b>
+                4
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-6"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-17"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-18"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-19"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-20"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </div>
+  </div>
+  <table
+    aria-label="Products"
+    class="pf-c-table pf-m-grid-md"
+    data-ouia-component-id="OUIA-Generated-Table-3"
+    data-ouia-component-type="PF4/Table"
+    data-ouia-safe="true"
+    role="grid"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-8"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <th
+          aria-sort="descending"
+          class="pf-c-table__sort pf-m-selected"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Name
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M168 345.941V44c0-6.627-5.373-12-12-12h-56c-6.627 0-12 5.373-12 12v301.941H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.569 9.373 33.941 0l86.059-86.059c15.119-15.119 4.411-40.971-16.971-40.971H168z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+        <th
+          aria-sort="none"
+          class="pf-c-table__sort"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Quantity
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+      role="rowgroup"
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-9"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-11"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Z
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-12"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-10"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-13"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              A
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-14"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                vowels
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          3
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-11"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-15"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-16"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              />
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        />
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-12"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-17"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-18"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                consonants
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          2
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div
+    class="pf-c-pagination pf-m-bottom"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-3"
+    data-ouia-component-type="PF4/Pagination"
+    data-ouia-safe="true"
+    id="pagination-options-menu-7"
+    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+  >
+    <div
+      class="pf-c-options-menu pf-m-top"
+      data-ouia-component-type="PF4/PaginationOptionsMenu"
+      data-ouia-safe="true"
+    >
+      <div
+        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+      >
+        <span
+          class="pf-c-options-menu__toggle-text"
+        >
+          <b>
+            1
+             - 
+            4
+          </b>
+           
+          of
+           
+          <b>
+            4
+          </b>
+           
+          
+        </span>
+        <button
+          aria-expanded="false"
+          aria-label="Items per page"
+          class="  pf-c-options-menu__toggle-button"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
+          data-ouia-component-type="PF4/DropdownToggle"
+          data-ouia-safe="true"
+          id="pagination-options-menu-toggle-7"
+          type="button"
+        >
+          <span
+            class="pf-c-options-menu__toggle-button-icon"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <nav
+      aria-label="Pagination"
+      class="pf-c-pagination__nav"
+    >
+      <div
+        class="pf-c-pagination__nav-control pf-m-first"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to first page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="first"
+          data-ouia-component-id="OUIA-Generated-Button-plain-21"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to previous page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="previous"
+          data-ouia-component-id="OUIA-Generated-Button-plain-22"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-page-select"
+      >
+        <input
+          aria-label="Current page"
+          class="pf-c-form-control"
+          disabled=""
+          max="1"
+          min="1"
+          type="number"
+          value="1"
+        />
+        <span
+          aria-hidden="true"
+        >
+          of
+           
+          1
+        </span>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to next page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="next"
+          data-ouia-component-id="OUIA-Generated-Button-plain-23"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control pf-m-last"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to last page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="last"
+          data-ouia-component-id="OUIA-Generated-Button-plain-24"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
+        </button>
+      </div>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`ProductsTable when row column headings are clicked can sort by quantity 1`] = `
+<div>
+  <div
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
+  >
+    <div
+      class=""
+    >
+      <div
+        class="pf-c-search-input"
+      >
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-4"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-10"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
+        >
+          <b>
+            1
+             - 
+            4
+          </b>
+           
+          of
+           
+          <b>
+            4
+          </b>
+           
+          
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
+          data-ouia-safe="true"
+        >
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+          >
+            <span
+              class="pf-c-options-menu__toggle-text"
+            >
+              <b>
+                1
+                 - 
+                4
+              </b>
+               
+              of
+               
+              <b>
+                4
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-10"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-25"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-26"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-27"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-28"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </div>
+  </div>
+  <table
+    aria-label="Products"
+    class="pf-c-table pf-m-grid-md"
+    data-ouia-component-id="OUIA-Generated-Table-4"
+    data-ouia-component-type="PF4/Table"
+    data-ouia-safe="true"
+    role="grid"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-13"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <th
+          aria-sort="none"
+          class="pf-c-table__sort"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Name
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+        <th
+          aria-sort="ascending"
+          class="pf-c-table__sort pf-m-selected"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Quantity
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+      role="rowgroup"
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-14"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-19"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-20"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              />
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        />
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-15"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-21"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Z
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-22"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-16"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-23"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-24"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                consonants
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          2
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-17"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-25"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              A
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-26"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                vowels
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          3
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div
+    class="pf-c-pagination pf-m-bottom"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-4"
+    data-ouia-component-type="PF4/Pagination"
+    data-ouia-safe="true"
+    id="pagination-options-menu-11"
+    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+  >
+    <div
+      class="pf-c-options-menu pf-m-top"
+      data-ouia-component-type="PF4/PaginationOptionsMenu"
+      data-ouia-safe="true"
+    >
+      <div
+        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+      >
+        <span
+          class="pf-c-options-menu__toggle-text"
+        >
+          <b>
+            1
+             - 
+            4
+          </b>
+           
+          of
+           
+          <b>
+            4
+          </b>
+           
+          
+        </span>
+        <button
+          aria-expanded="false"
+          aria-label="Items per page"
+          class="  pf-c-options-menu__toggle-button"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-8"
+          data-ouia-component-type="PF4/DropdownToggle"
+          data-ouia-safe="true"
+          id="pagination-options-menu-toggle-11"
+          type="button"
+        >
+          <span
+            class="pf-c-options-menu__toggle-button-icon"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <nav
+      aria-label="Pagination"
+      class="pf-c-pagination__nav"
+    >
+      <div
+        class="pf-c-pagination__nav-control pf-m-first"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to first page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="first"
+          data-ouia-component-id="OUIA-Generated-Button-plain-29"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to previous page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="previous"
+          data-ouia-component-id="OUIA-Generated-Button-plain-30"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-page-select"
+      >
+        <input
+          aria-label="Current page"
+          class="pf-c-form-control"
+          disabled=""
+          max="1"
+          min="1"
+          type="number"
+          value="1"
+        />
+        <span
+          aria-hidden="true"
+        >
+          of
+           
+          1
+        </span>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to next page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="next"
+          data-ouia-component-id="OUIA-Generated-Button-plain-31"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control pf-m-last"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to last page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="last"
+          data-ouia-component-id="OUIA-Generated-Button-plain-32"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
+        </button>
+      </div>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`ProductsTable when row column headings are clicked can sort by quantity, reversed 1`] = `
+<div>
+  <div
+    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
+  >
+    <div
+      class=""
+    >
+      <div
+        class="pf-c-search-input"
+      >
+        <div
+          class="pf-c-input-group"
+        >
+          <div
+            class="pf-c-search-input__bar"
+          >
+            <span
+              class="pf-c-search-input__text"
+            >
+              <span
+                class="pf-c-search-input__icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+              </span>
+              <input
+                aria-label="Search input"
+                class="pf-c-search-input__text-input"
+                placeholder="Filter by Name"
+                value=""
+              />
+            </span>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-m-align-right"
+    >
+      <div
+        class="pf-c-pagination"
+        data-ouia-component-id="OUIA-Generated-Pagination-top-5"
+        data-ouia-component-type="PF4/Pagination"
+        data-ouia-safe="true"
+        id="pagination-options-menu-16"
+        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+      >
+        <div
+          class="pf-c-pagination__total-items"
+        >
+          <b>
+            1
+             - 
+            4
+          </b>
+           
+          of
+           
+          <b>
+            4
+          </b>
+           
+          
+        </div>
+        <div
+          class="pf-c-options-menu"
+          data-ouia-component-type="PF4/PaginationOptionsMenu"
+          data-ouia-safe="true"
+        >
+          <div
+            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+          >
+            <span
+              class="pf-c-options-menu__toggle-text"
+            >
+              <b>
+                1
+                 - 
+                4
+              </b>
+               
+              of
+               
+              <b>
+                4
+              </b>
+               
+              
+            </span>
+            <button
+              aria-expanded="false"
+              aria-label="Items per page"
+              class="  pf-c-options-menu__toggle-button"
+              data-ouia-component-id="OUIA-Generated-DropdownToggle-9"
+              data-ouia-component-type="PF4/DropdownToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-toggle-16"
+              type="button"
+            >
+              <span
+                class="pf-c-options-menu__toggle-button-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <nav
+          aria-label="Pagination"
+          class="pf-c-pagination__nav"
+        >
+          <div
+            class="pf-c-pagination__nav-control pf-m-first"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to first page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="first"
+              data-ouia-component-id="OUIA-Generated-Button-plain-33"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="previous"
+              data-ouia-component-id="OUIA-Generated-Button-plain-34"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              class="pf-c-form-control"
+              disabled=""
+              max="1"
+              min="1"
+              type="number"
+              value="1"
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to next page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="next"
+              data-ouia-component-id="OUIA-Generated-Button-plain-35"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-pagination__nav-control pf-m-last"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to last page"
+              class="pf-c-button pf-m-plain pf-m-disabled"
+              data-action="last"
+              data-ouia-component-id="OUIA-Generated-Button-plain-36"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </div>
+  </div>
+  <table
+    aria-label="Products"
+    class="pf-c-table pf-m-grid-md"
+    data-ouia-component-id="OUIA-Generated-Table-5"
+    data-ouia-component-type="PF4/Table"
+    data-ouia-safe="true"
+    role="grid"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-18"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <th
+          aria-sort="none"
+          class="pf-c-table__sort"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Name
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+        <th
+          aria-sort="descending"
+          class="pf-c-table__sort pf-m-selected"
+          scope="col"
+        >
+          <button
+            class="pf-c-table__button"
+            type="button"
+          >
+            <div
+              class="pf-c-table__button-content"
+            >
+              <span
+                class="pf-c-table__text"
+              >
+                Quantity
+              </span>
+              <span
+                class="pf-c-table__sort-indicator"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M168 345.941V44c0-6.627-5.373-12-12-12h-56c-6.627 0-12 5.373-12 12v301.941H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.569 9.373 33.941 0l86.059-86.059c15.119-15.119 4.411-40.971-16.971-40.971H168z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+      role="rowgroup"
+    >
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-19"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-27"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              A
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-28"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                vowels
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          3
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-20"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-29"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-30"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                consonants
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          2
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-21"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-31"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Z
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-32"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-22"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-33"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-34"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              />
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        />
+      </tr>
+    </tbody>
+  </table>
+  <div
+    class="pf-c-pagination pf-m-bottom"
+    data-ouia-component-id="OUIA-Generated-Pagination-bottom-5"
+    data-ouia-component-type="PF4/Pagination"
+    data-ouia-safe="true"
+    id="pagination-options-menu-17"
+    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+  >
+    <div
+      class="pf-c-options-menu pf-m-top"
+      data-ouia-component-type="PF4/PaginationOptionsMenu"
+      data-ouia-safe="true"
+    >
+      <div
+        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+      >
+        <span
+          class="pf-c-options-menu__toggle-text"
+        >
+          <b>
+            1
+             - 
+            4
+          </b>
+           
+          of
+           
+          <b>
+            4
+          </b>
+           
+          
+        </span>
+        <button
+          aria-expanded="false"
+          aria-label="Items per page"
+          class="  pf-c-options-menu__toggle-button"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-10"
+          data-ouia-component-type="PF4/DropdownToggle"
+          data-ouia-safe="true"
+          id="pagination-options-menu-toggle-17"
+          type="button"
+        >
+          <span
+            class="pf-c-options-menu__toggle-button-icon"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <nav
+      aria-label="Pagination"
+      class="pf-c-pagination__nav"
+    >
+      <div
+        class="pf-c-pagination__nav-control pf-m-first"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to first page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="first"
+          data-ouia-component-id="OUIA-Generated-Button-plain-37"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to previous page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="previous"
+          data-ouia-component-id="OUIA-Generated-Button-plain-38"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-page-select"
+      >
+        <input
+          aria-label="Current page"
+          class="pf-c-form-control"
+          disabled=""
+          max="1"
+          min="1"
+          type="number"
+          value="1"
+        />
+        <span
+          aria-hidden="true"
+        >
+          of
+           
+          1
+        </span>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to next page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="next"
+          data-ouia-component-id="OUIA-Generated-Button-plain-39"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-pagination__nav-control pf-m-last"
+      >
+        <button
+          aria-disabled="true"
+          aria-label="Go to last page"
+          class="pf-c-button pf-m-plain pf-m-disabled"
+          data-action="last"
+          data-ouia-component-id="OUIA-Generated-Button-plain-40"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          disabled=""
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
+        </button>
+      </div>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`ProductsTable when row column headings are clicked sorts by name by default 1`] = `
 <div>
   <div
     class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
@@ -681,7 +2904,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
         data-ouia-component-id="OUIA-Generated-Pagination-top-2"
         data-ouia-component-type="PF4/Pagination"
         data-ouia-safe="true"
-        id="pagination-options-menu-4"
+        id="pagination-options-menu-2"
         style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
       >
         <div
@@ -690,13 +2913,13 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
           <b>
             1
              - 
-            3
+            4
           </b>
            
           of
            
           <b>
-            3
+            4
           </b>
            
           
@@ -715,13 +2938,13 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
               <b>
                 1
                  - 
-                3
+                4
               </b>
                
               of
                
               <b>
-                3
+                4
               </b>
                
               
@@ -733,7 +2956,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
               data-ouia-component-id="OUIA-Generated-DropdownToggle-3"
               data-ouia-component-type="PF4/DropdownToggle"
               data-ouia-safe="true"
-              id="pagination-options-menu-toggle-4"
+              id="pagination-options-menu-toggle-2"
               type="button"
             >
               <span
@@ -1017,7 +3240,6 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
               data-ouia-safe="true"
               data-pf-content="true"
             >
-              A
               <br />
               <small
                 class=""
@@ -1025,18 +3247,14 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
-              >
-                letters
-              </small>
+              />
             </h3>
           </div>
         </td>
         <td
           class=""
           data-label="Quantity"
-        >
-          3
-        </td>
+        />
       </tr>
       <tr
         class=""
@@ -1058,7 +3276,6 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
               data-ouia-safe="true"
               data-pf-content="true"
             >
-              B
               <br />
               <small
                 class=""
@@ -1067,7 +3284,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
                 data-ouia-safe="true"
                 data-pf-content="true"
               >
-                letters
+                consonants
               </small>
             </h3>
           </div>
@@ -1099,11 +3316,52 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
               data-ouia-safe="true"
               data-pf-content="true"
             >
-              Z
+              A
               <br />
               <small
                 class=""
                 data-ouia-component-id="OUIA-Generated-Text-8"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                vowels
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          3
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-7"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-9"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Z
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-10"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -1127,7 +3385,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
     data-ouia-component-id="OUIA-Generated-Pagination-bottom-2"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
-    id="pagination-options-menu-5"
+    id="pagination-options-menu-3"
     style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
   >
     <div
@@ -1144,13 +3402,13 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
           <b>
             1
              - 
-            3
+            4
           </b>
            
           of
            
           <b>
-            3
+            4
           </b>
            
           
@@ -1162,7 +3420,7 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
           data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-5"
+          id="pagination-options-menu-toggle-3"
           type="button"
         >
           <span
@@ -1330,2124 +3588,6 @@ exports[`ProductsTable when row column headings are clicked can sort by name 1`]
 </div>
 `;
 
-exports[`ProductsTable when row column headings are clicked can sort by name, reversed 1`] = `
-<div>
-  <div
-    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
-  >
-    <div
-      class=""
-    >
-      <div
-        class="pf-c-search-input"
-      >
-        <div
-          class="pf-c-input-group"
-        >
-          <div
-            class="pf-c-search-input__bar"
-          >
-            <span
-              class="pf-c-search-input__text"
-            >
-              <span
-                class="pf-c-search-input__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                  />
-                </svg>
-              </span>
-              <input
-                aria-label="Search input"
-                class="pf-c-search-input__text-input"
-                placeholder="Filter by Name"
-                value=""
-              />
-            </span>
-            
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="pf-m-align-right"
-    >
-      <div
-        class="pf-c-pagination"
-        data-ouia-component-id="OUIA-Generated-Pagination-top-3"
-        data-ouia-component-type="PF4/Pagination"
-        data-ouia-safe="true"
-        id="pagination-options-menu-10"
-        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-      >
-        <div
-          class="pf-c-pagination__total-items"
-        >
-          <b>
-            1
-             - 
-            3
-          </b>
-           
-          of
-           
-          <b>
-            3
-          </b>
-           
-          
-        </div>
-        <div
-          class="pf-c-options-menu"
-          data-ouia-component-type="PF4/PaginationOptionsMenu"
-          data-ouia-safe="true"
-        >
-          <div
-            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-          >
-            <span
-              class="pf-c-options-menu__toggle-text"
-            >
-              <b>
-                1
-                 - 
-                3
-              </b>
-               
-              of
-               
-              <b>
-                3
-              </b>
-               
-              
-            </span>
-            <button
-              aria-expanded="false"
-              aria-label="Items per page"
-              class="  pf-c-options-menu__toggle-button"
-              data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
-              data-ouia-component-type="PF4/DropdownToggle"
-              data-ouia-safe="true"
-              id="pagination-options-menu-toggle-10"
-              type="button"
-            >
-              <span
-                class="pf-c-options-menu__toggle-button-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </div>
-        <nav
-          aria-label="Pagination"
-          class="pf-c-pagination__nav"
-        >
-          <div
-            class="pf-c-pagination__nav-control pf-m-first"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to first page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-17"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 448 512"
-                width="1em"
-              >
-                <path
-                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pf-c-pagination__nav-control"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to previous page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-18"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 256 512"
-                width="1em"
-              >
-                <path
-                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pf-c-pagination__nav-page-select"
-          >
-            <input
-              aria-label="Current page"
-              class="pf-c-form-control"
-              disabled=""
-              max="1"
-              min="1"
-              type="number"
-              value="1"
-            />
-            <span
-              aria-hidden="true"
-            >
-              of
-               
-              1
-            </span>
-          </div>
-          <div
-            class="pf-c-pagination__nav-control"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to next page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-19"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 256 512"
-                width="1em"
-              >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pf-c-pagination__nav-control pf-m-last"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to last page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-20"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 448 512"
-                width="1em"
-              >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                />
-              </svg>
-            </button>
-          </div>
-        </nav>
-      </div>
-    </div>
-  </div>
-  <table
-    aria-label="Products"
-    class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="OUIA-Generated-Table-3"
-    data-ouia-component-type="PF4/Table"
-    data-ouia-safe="true"
-    role="grid"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-7"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <th
-          aria-sort="descending"
-          class="pf-c-table__sort pf-m-selected"
-          scope="col"
-        >
-          <button
-            class="pf-c-table__button"
-            type="button"
-          >
-            <div
-              class="pf-c-table__button-content"
-            >
-              <span
-                class="pf-c-table__text"
-              >
-                Name
-              </span>
-              <span
-                class="pf-c-table__sort-indicator"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M168 345.941V44c0-6.627-5.373-12-12-12h-56c-6.627 0-12 5.373-12 12v301.941H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.569 9.373 33.941 0l86.059-86.059c15.119-15.119 4.411-40.971-16.971-40.971H168z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </button>
-        </th>
-        <th
-          aria-sort="none"
-          class="pf-c-table__sort"
-          scope="col"
-        >
-          <button
-            class="pf-c-table__button"
-            type="button"
-          >
-            <div
-              class="pf-c-table__button-content"
-            >
-              <span
-                class="pf-c-table__text"
-              >
-                Quantity
-              </span>
-              <span
-                class="pf-c-table__sort-indicator"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </button>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class=""
-      role="rowgroup"
-    >
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-8"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-9"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              Z
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-10"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          1
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-9"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-11"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              B
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-12"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          2
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-10"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-13"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              A
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-14"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          3
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <div
-    class="pf-c-pagination pf-m-bottom"
-    data-ouia-component-id="OUIA-Generated-Pagination-bottom-3"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-11"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-  >
-    <div
-      class="pf-c-options-menu pf-m-top"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
-    >
-      <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-      >
-        <span
-          class="pf-c-options-menu__toggle-text"
-        >
-          <b>
-            1
-             - 
-            3
-          </b>
-           
-          of
-           
-          <b>
-            3
-          </b>
-           
-          
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
-          data-ouia-component-type="PF4/DropdownToggle"
-          data-ouia-safe="true"
-          id="pagination-options-menu-toggle-11"
-          type="button"
-        >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
-            >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-    </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-21"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-22"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          disabled=""
-          max="1"
-          min="1"
-          type="number"
-          value="1"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          1
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-23"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-24"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`ProductsTable when row column headings are clicked can sort by quantity 1`] = `
-<div>
-  <div
-    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
-  >
-    <div
-      class=""
-    >
-      <div
-        class="pf-c-search-input"
-      >
-        <div
-          class="pf-c-input-group"
-        >
-          <div
-            class="pf-c-search-input__bar"
-          >
-            <span
-              class="pf-c-search-input__text"
-            >
-              <span
-                class="pf-c-search-input__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                  />
-                </svg>
-              </span>
-              <input
-                aria-label="Search input"
-                class="pf-c-search-input__text-input"
-                placeholder="Filter by Name"
-                value=""
-              />
-            </span>
-            
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="pf-m-align-right"
-    >
-      <div
-        class="pf-c-pagination"
-        data-ouia-component-id="OUIA-Generated-Pagination-top-4"
-        data-ouia-component-type="PF4/Pagination"
-        data-ouia-safe="true"
-        id="pagination-options-menu-14"
-        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-      >
-        <div
-          class="pf-c-pagination__total-items"
-        >
-          <b>
-            1
-             - 
-            3
-          </b>
-           
-          of
-           
-          <b>
-            3
-          </b>
-           
-          
-        </div>
-        <div
-          class="pf-c-options-menu"
-          data-ouia-component-type="PF4/PaginationOptionsMenu"
-          data-ouia-safe="true"
-        >
-          <div
-            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-          >
-            <span
-              class="pf-c-options-menu__toggle-text"
-            >
-              <b>
-                1
-                 - 
-                3
-              </b>
-               
-              of
-               
-              <b>
-                3
-              </b>
-               
-              
-            </span>
-            <button
-              aria-expanded="false"
-              aria-label="Items per page"
-              class="  pf-c-options-menu__toggle-button"
-              data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
-              data-ouia-component-type="PF4/DropdownToggle"
-              data-ouia-safe="true"
-              id="pagination-options-menu-toggle-14"
-              type="button"
-            >
-              <span
-                class="pf-c-options-menu__toggle-button-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </div>
-        <nav
-          aria-label="Pagination"
-          class="pf-c-pagination__nav"
-        >
-          <div
-            class="pf-c-pagination__nav-control pf-m-first"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to first page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-25"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 448 512"
-                width="1em"
-              >
-                <path
-                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pf-c-pagination__nav-control"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to previous page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-26"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 256 512"
-                width="1em"
-              >
-                <path
-                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pf-c-pagination__nav-page-select"
-          >
-            <input
-              aria-label="Current page"
-              class="pf-c-form-control"
-              disabled=""
-              max="1"
-              min="1"
-              type="number"
-              value="1"
-            />
-            <span
-              aria-hidden="true"
-            >
-              of
-               
-              1
-            </span>
-          </div>
-          <div
-            class="pf-c-pagination__nav-control"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to next page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-27"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 256 512"
-                width="1em"
-              >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pf-c-pagination__nav-control pf-m-last"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to last page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-28"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 448 512"
-                width="1em"
-              >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                />
-              </svg>
-            </button>
-          </div>
-        </nav>
-      </div>
-    </div>
-  </div>
-  <table
-    aria-label="Products"
-    class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="OUIA-Generated-Table-4"
-    data-ouia-component-type="PF4/Table"
-    data-ouia-safe="true"
-    role="grid"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-11"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <th
-          aria-sort="none"
-          class="pf-c-table__sort"
-          scope="col"
-        >
-          <button
-            class="pf-c-table__button"
-            type="button"
-          >
-            <div
-              class="pf-c-table__button-content"
-            >
-              <span
-                class="pf-c-table__text"
-              >
-                Name
-              </span>
-              <span
-                class="pf-c-table__sort-indicator"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </button>
-        </th>
-        <th
-          aria-sort="ascending"
-          class="pf-c-table__sort pf-m-selected"
-          scope="col"
-        >
-          <button
-            class="pf-c-table__button"
-            type="button"
-          >
-            <div
-              class="pf-c-table__button-content"
-            >
-              <span
-                class="pf-c-table__text"
-              >
-                Quantity
-              </span>
-              <span
-                class="pf-c-table__sort-indicator"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </button>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class=""
-      role="rowgroup"
-    >
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-12"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-15"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              Z
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-16"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          1
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-13"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-17"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              B
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-18"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          2
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-14"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-19"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              A
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-20"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          3
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <div
-    class="pf-c-pagination pf-m-bottom"
-    data-ouia-component-id="OUIA-Generated-Pagination-bottom-4"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-15"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-  >
-    <div
-      class="pf-c-options-menu pf-m-top"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
-    >
-      <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-      >
-        <span
-          class="pf-c-options-menu__toggle-text"
-        >
-          <b>
-            1
-             - 
-            3
-          </b>
-           
-          of
-           
-          <b>
-            3
-          </b>
-           
-          
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-8"
-          data-ouia-component-type="PF4/DropdownToggle"
-          data-ouia-safe="true"
-          id="pagination-options-menu-toggle-15"
-          type="button"
-        >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
-            >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-    </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-29"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-30"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          disabled=""
-          max="1"
-          min="1"
-          type="number"
-          value="1"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          1
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-31"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-32"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`ProductsTable when row column headings are clicked can sort by quantity, reversed 1`] = `
-<div>
-  <div
-    class="pf-l-flex pf-m-column pf-m-row-on-md pf-m-justify-content-space-between"
-  >
-    <div
-      class=""
-    >
-      <div
-        class="pf-c-search-input"
-      >
-        <div
-          class="pf-c-input-group"
-        >
-          <div
-            class="pf-c-search-input__bar"
-          >
-            <span
-              class="pf-c-search-input__text"
-            >
-              <span
-                class="pf-c-search-input__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                  />
-                </svg>
-              </span>
-              <input
-                aria-label="Search input"
-                class="pf-c-search-input__text-input"
-                placeholder="Filter by Name"
-                value=""
-              />
-            </span>
-            
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="pf-m-align-right"
-    >
-      <div
-        class="pf-c-pagination"
-        data-ouia-component-id="OUIA-Generated-Pagination-top-5"
-        data-ouia-component-type="PF4/Pagination"
-        data-ouia-safe="true"
-        id="pagination-options-menu-20"
-        style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-      >
-        <div
-          class="pf-c-pagination__total-items"
-        >
-          <b>
-            1
-             - 
-            3
-          </b>
-           
-          of
-           
-          <b>
-            3
-          </b>
-           
-          
-        </div>
-        <div
-          class="pf-c-options-menu"
-          data-ouia-component-type="PF4/PaginationOptionsMenu"
-          data-ouia-safe="true"
-        >
-          <div
-            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-          >
-            <span
-              class="pf-c-options-menu__toggle-text"
-            >
-              <b>
-                1
-                 - 
-                3
-              </b>
-               
-              of
-               
-              <b>
-                3
-              </b>
-               
-              
-            </span>
-            <button
-              aria-expanded="false"
-              aria-label="Items per page"
-              class="  pf-c-options-menu__toggle-button"
-              data-ouia-component-id="OUIA-Generated-DropdownToggle-9"
-              data-ouia-component-type="PF4/DropdownToggle"
-              data-ouia-safe="true"
-              id="pagination-options-menu-toggle-20"
-              type="button"
-            >
-              <span
-                class="pf-c-options-menu__toggle-button-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </div>
-        <nav
-          aria-label="Pagination"
-          class="pf-c-pagination__nav"
-        >
-          <div
-            class="pf-c-pagination__nav-control pf-m-first"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to first page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-33"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 448 512"
-                width="1em"
-              >
-                <path
-                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pf-c-pagination__nav-control"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to previous page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-34"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 256 512"
-                width="1em"
-              >
-                <path
-                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pf-c-pagination__nav-page-select"
-          >
-            <input
-              aria-label="Current page"
-              class="pf-c-form-control"
-              disabled=""
-              max="1"
-              min="1"
-              type="number"
-              value="1"
-            />
-            <span
-              aria-hidden="true"
-            >
-              of
-               
-              1
-            </span>
-          </div>
-          <div
-            class="pf-c-pagination__nav-control"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to next page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-35"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 256 512"
-                width="1em"
-              >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pf-c-pagination__nav-control pf-m-last"
-          >
-            <button
-              aria-disabled="true"
-              aria-label="Go to last page"
-              class="pf-c-button pf-m-plain pf-m-disabled"
-              data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-36"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 448 512"
-                width="1em"
-              >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                />
-              </svg>
-            </button>
-          </div>
-        </nav>
-      </div>
-    </div>
-  </div>
-  <table
-    aria-label="Products"
-    class="pf-c-table pf-m-grid-md"
-    data-ouia-component-id="OUIA-Generated-Table-5"
-    data-ouia-component-type="PF4/Table"
-    data-ouia-safe="true"
-    role="grid"
-  >
-    <thead
-      class=""
-    >
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-15"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <th
-          aria-sort="none"
-          class="pf-c-table__sort"
-          scope="col"
-        >
-          <button
-            class="pf-c-table__button"
-            type="button"
-          >
-            <div
-              class="pf-c-table__button-content"
-            >
-              <span
-                class="pf-c-table__text"
-              >
-                Name
-              </span>
-              <span
-                class="pf-c-table__sort-indicator"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </button>
-        </th>
-        <th
-          aria-sort="descending"
-          class="pf-c-table__sort pf-m-selected"
-          scope="col"
-        >
-          <button
-            class="pf-c-table__button"
-            type="button"
-          >
-            <div
-              class="pf-c-table__button-content"
-            >
-              <span
-                class="pf-c-table__text"
-              >
-                Quantity
-              </span>
-              <span
-                class="pf-c-table__sort-indicator"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M168 345.941V44c0-6.627-5.373-12-12-12h-56c-6.627 0-12 5.373-12 12v301.941H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.569 9.373 33.941 0l86.059-86.059c15.119-15.119 4.411-40.971-16.971-40.971H168z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </button>
-        </th>
-      </tr>
-    </thead>
-    <tbody
-      class=""
-      role="rowgroup"
-    >
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-16"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-21"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              A
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-22"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          3
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-17"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-23"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              B
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-24"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          2
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-18"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-25"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              Z
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-26"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          1
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <div
-    class="pf-c-pagination pf-m-bottom"
-    data-ouia-component-id="OUIA-Generated-Pagination-bottom-5"
-    data-ouia-component-type="PF4/Pagination"
-    data-ouia-safe="true"
-    id="pagination-options-menu-21"
-    style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-  >
-    <div
-      class="pf-c-options-menu pf-m-top"
-      data-ouia-component-type="PF4/PaginationOptionsMenu"
-      data-ouia-safe="true"
-    >
-      <div
-        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-      >
-        <span
-          class="pf-c-options-menu__toggle-text"
-        >
-          <b>
-            1
-             - 
-            3
-          </b>
-           
-          of
-           
-          <b>
-            3
-          </b>
-           
-          
-        </span>
-        <button
-          aria-expanded="false"
-          aria-label="Items per page"
-          class="  pf-c-options-menu__toggle-button"
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-10"
-          data-ouia-component-type="PF4/DropdownToggle"
-          data-ouia-safe="true"
-          id="pagination-options-menu-toggle-21"
-          type="button"
-        >
-          <span
-            class="pf-c-options-menu__toggle-button-icon"
-          >
-            <svg
-              aria-hidden="true"
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 320 512"
-              width="1em"
-            >
-              <path
-                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-    </div>
-    <nav
-      aria-label="Pagination"
-      class="pf-c-pagination__nav"
-    >
-      <div
-        class="pf-c-pagination__nav-control pf-m-first"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to first page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="first"
-          data-ouia-component-id="OUIA-Generated-Button-plain-37"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to previous page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="previous"
-          data-ouia-component-id="OUIA-Generated-Button-plain-38"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-page-select"
-      >
-        <input
-          aria-label="Current page"
-          class="pf-c-form-control"
-          disabled=""
-          max="1"
-          min="1"
-          type="number"
-          value="1"
-        />
-        <span
-          aria-hidden="true"
-        >
-          of
-           
-          1
-        </span>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to next page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="next"
-          data-ouia-component-id="OUIA-Generated-Button-plain-39"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 256 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="pf-c-pagination__nav-control pf-m-last"
-      >
-        <button
-          aria-disabled="true"
-          aria-label="Go to last page"
-          class="pf-c-button pf-m-plain pf-m-disabled"
-          data-action="last"
-          data-ouia-component-id="OUIA-Generated-Button-plain-40"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align: -0.125em;"
-            viewBox="0 0 448 512"
-            width="1em"
-          >
-            <path
-              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </nav>
-  </div>
-</div>
-`;
-
 exports[`ProductsTable when the search is used can be cleared 1`] = `
 <div>
   <div
@@ -3505,7 +3645,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
         data-ouia-component-id="OUIA-Generated-Pagination-top-10"
         data-ouia-component-type="PF4/Pagination"
         data-ouia-safe="true"
-        id="pagination-options-menu-42"
+        id="pagination-options-menu-38"
         style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
       >
         <div
@@ -3557,7 +3697,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               data-ouia-component-id="OUIA-Generated-DropdownToggle-19"
               data-ouia-component-type="PF4/DropdownToggle"
               data-ouia-safe="true"
-              id="pagination-options-menu-toggle-43"
+              id="pagination-options-menu-toggle-39"
               type="button"
             >
               <span
@@ -3737,13 +3877,13 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-52"
+        data-ouia-component-id="OUIA-Generated-TableRow-56"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
         <th
-          aria-sort="none"
-          class="pf-c-table__sort"
+          aria-sort="ascending"
+          class="pf-c-table__sort pf-m-selected"
           scope="col"
         >
           <button
@@ -3771,7 +3911,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                    d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
                   />
                 </svg>
               </span>
@@ -3823,47 +3963,6 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-53"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-85"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              Z
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-86"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                consonants
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          2
-        </td>
-      </tr>
-      <tr
-        class=""
         data-ouia-component-id="OUIA-Generated-TableRow-57"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
@@ -3882,11 +3981,49 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               data-ouia-safe="true"
               data-pf-content="true"
             >
-              A
               <br />
               <small
                 class=""
                 data-ouia-component-id="OUIA-Generated-Text-94"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              />
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          0
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-61"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-101"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              A
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-102"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -3905,7 +4042,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-58"
+        data-ouia-component-id="OUIA-Generated-TableRow-62"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -3918,7 +4055,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-95"
+              data-ouia-component-id="OUIA-Generated-Text-103"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -3927,7 +4064,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-96"
+                data-ouia-component-id="OUIA-Generated-Text-104"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -3946,7 +4083,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
       </tr>
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-59"
+        data-ouia-component-id="OUIA-Generated-TableRow-63"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -3959,19 +4096,22 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-97"
+              data-ouia-component-id="OUIA-Generated-Text-105"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
             >
+              Z
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-98"
+                data-ouia-component-id="OUIA-Generated-Text-106"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
-              />
+              >
+                consonants
+              </small>
             </h3>
           </div>
         </td>
@@ -3979,7 +4119,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           class=""
           data-label="Quantity"
         >
-          0
+          2
         </td>
       </tr>
     </tbody>
@@ -3989,7 +4129,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
     data-ouia-component-id="OUIA-Generated-Pagination-bottom-10"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
-    id="pagination-options-menu-43"
+    id="pagination-options-menu-39"
     style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
   >
     <div
@@ -4024,7 +4164,7 @@ exports[`ProductsTable when the search is used can be cleared 1`] = `
           data-ouia-component-id="OUIA-Generated-DropdownToggle-20"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-44"
+          id="pagination-options-menu-toggle-40"
           type="button"
         >
           <span
@@ -4279,7 +4419,7 @@ exports[`ProductsTable when the search is used refines the results by name 1`] =
         data-ouia-component-id="OUIA-Generated-Pagination-top-8"
         data-ouia-component-type="PF4/Pagination"
         data-ouia-safe="true"
-        id="pagination-options-menu-32"
+        id="pagination-options-menu-28"
         style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
       >
         <div
@@ -4331,7 +4471,7 @@ exports[`ProductsTable when the search is used refines the results by name 1`] =
               data-ouia-component-id="OUIA-Generated-DropdownToggle-15"
               data-ouia-component-type="PF4/DropdownToggle"
               data-ouia-safe="true"
-              id="pagination-options-menu-toggle-33"
+              id="pagination-options-menu-toggle-29"
               type="button"
             >
               <span
@@ -4511,13 +4651,13 @@ exports[`ProductsTable when the search is used refines the results by name 1`] =
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-42"
+        data-ouia-component-id="OUIA-Generated-TableRow-46"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
         <th
-          aria-sort="none"
-          class="pf-c-table__sort"
+          aria-sort="ascending"
+          class="pf-c-table__sort pf-m-selected"
           scope="col"
         >
           <button
@@ -4545,7 +4685,7 @@ exports[`ProductsTable when the search is used refines the results by name 1`] =
                   width="1em"
                 >
                   <path
-                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                    d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
                   />
                 </svg>
               </span>
@@ -4597,7 +4737,7 @@ exports[`ProductsTable when the search is used refines the results by name 1`] =
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-43"
+        data-ouia-component-id="OUIA-Generated-TableRow-47"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -4610,7 +4750,7 @@ exports[`ProductsTable when the search is used refines the results by name 1`] =
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-69"
+              data-ouia-component-id="OUIA-Generated-Text-77"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -4619,7 +4759,7 @@ exports[`ProductsTable when the search is used refines the results by name 1`] =
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-70"
+                data-ouia-component-id="OUIA-Generated-Text-78"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -4643,7 +4783,7 @@ exports[`ProductsTable when the search is used refines the results by name 1`] =
     data-ouia-component-id="OUIA-Generated-Pagination-bottom-8"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
-    id="pagination-options-menu-33"
+    id="pagination-options-menu-29"
     style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
   >
     <div
@@ -4678,7 +4818,7 @@ exports[`ProductsTable when the search is used refines the results by name 1`] =
           data-ouia-component-id="OUIA-Generated-DropdownToggle-16"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-34"
+          id="pagination-options-menu-toggle-30"
           type="button"
         >
           <span
@@ -4933,7 +5073,7 @@ exports[`ProductsTable when the search is used refines the results by product li
         data-ouia-component-id="OUIA-Generated-Pagination-top-9"
         data-ouia-component-type="PF4/Pagination"
         data-ouia-safe="true"
-        id="pagination-options-menu-36"
+        id="pagination-options-menu-32"
         style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
       >
         <div
@@ -4985,7 +5125,7 @@ exports[`ProductsTable when the search is used refines the results by product li
               data-ouia-component-id="OUIA-Generated-DropdownToggle-17"
               data-ouia-component-type="PF4/DropdownToggle"
               data-ouia-safe="true"
-              id="pagination-options-menu-toggle-37"
+              id="pagination-options-menu-toggle-33"
               type="button"
             >
               <span
@@ -5165,13 +5305,13 @@ exports[`ProductsTable when the search is used refines the results by product li
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-47"
+        data-ouia-component-id="OUIA-Generated-TableRow-51"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
         <th
-          aria-sort="none"
-          class="pf-c-table__sort"
+          aria-sort="ascending"
+          class="pf-c-table__sort pf-m-selected"
           scope="col"
         >
           <button
@@ -5199,7 +5339,7 @@ exports[`ProductsTable when the search is used refines the results by product li
                   width="1em"
                 >
                   <path
-                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                    d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
                   />
                 </svg>
               </span>
@@ -5251,7 +5391,7 @@ exports[`ProductsTable when the search is used refines the results by product li
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-48"
+        data-ouia-component-id="OUIA-Generated-TableRow-52"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -5264,7 +5404,7 @@ exports[`ProductsTable when the search is used refines the results by product li
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-77"
+              data-ouia-component-id="OUIA-Generated-Text-85"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -5273,7 +5413,7 @@ exports[`ProductsTable when the search is used refines the results by product li
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-78"
+                data-ouia-component-id="OUIA-Generated-Text-86"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -5297,7 +5437,7 @@ exports[`ProductsTable when the search is used refines the results by product li
     data-ouia-component-id="OUIA-Generated-Pagination-bottom-9"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
-    id="pagination-options-menu-37"
+    id="pagination-options-menu-33"
     style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
   >
     <div
@@ -5332,7 +5472,7 @@ exports[`ProductsTable when the search is used refines the results by product li
           data-ouia-component-id="OUIA-Generated-DropdownToggle-18"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-38"
+          id="pagination-options-menu-toggle-34"
           type="button"
         >
           <span
@@ -5557,7 +5697,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
         data-ouia-component-id="OUIA-Generated-Pagination-top-6"
         data-ouia-component-type="PF4/Pagination"
         data-ouia-safe="true"
-        id="pagination-options-menu-24"
+        id="pagination-options-menu-20"
         style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
       >
         <div
@@ -5609,7 +5749,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
               data-ouia-component-id="OUIA-Generated-DropdownToggle-11"
               data-ouia-component-type="PF4/DropdownToggle"
               data-ouia-safe="true"
-              id="pagination-options-menu-toggle-24"
+              id="pagination-options-menu-toggle-20"
               type="button"
             >
               <span
@@ -5786,13 +5926,13 @@ exports[`ProductsTable when using pagination can change page 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-19"
+        data-ouia-component-id="OUIA-Generated-TableRow-23"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
         <th
-          aria-sort="none"
-          class="pf-c-table__sort"
+          aria-sort="ascending"
+          class="pf-c-table__sort pf-m-selected"
           scope="col"
         >
           <button
@@ -5820,7 +5960,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                    d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
                   />
                 </svg>
               </span>
@@ -5872,7 +6012,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-20"
+        data-ouia-component-id="OUIA-Generated-TableRow-24"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -5885,7 +6025,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
           >
             <h3
               class=""
-              data-ouia-component-id="OUIA-Generated-Text-27"
+              data-ouia-component-id="OUIA-Generated-Text-35"
               data-ouia-component-type="PF4/Text"
               data-ouia-safe="true"
               data-pf-content="true"
@@ -5894,7 +6034,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
               <br />
               <small
                 class=""
-                data-ouia-component-id="OUIA-Generated-Text-28"
+                data-ouia-component-id="OUIA-Generated-Text-36"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -5918,7 +6058,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
     data-ouia-component-id="OUIA-Generated-Pagination-bottom-6"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
-    id="pagination-options-menu-25"
+    id="pagination-options-menu-21"
     style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
   >
     <div
@@ -5953,7 +6093,7 @@ exports[`ProductsTable when using pagination can change page 1`] = `
           data-ouia-component-id="OUIA-Generated-DropdownToggle-12"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-25"
+          id="pagination-options-menu-toggle-21"
           type="button"
         >
           <span
@@ -6175,7 +6315,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
         data-ouia-component-id="OUIA-Generated-Pagination-top-7"
         data-ouia-component-type="PF4/Pagination"
         data-ouia-safe="true"
-        id="pagination-options-menu-28"
+        id="pagination-options-menu-24"
         style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
       >
         <div
@@ -6227,7 +6367,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
               data-ouia-component-type="PF4/DropdownToggle"
               data-ouia-safe="true"
-              id="pagination-options-menu-toggle-29"
+              id="pagination-options-menu-toggle-25"
               type="button"
             >
               <span
@@ -6407,13 +6547,13 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
     >
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-30"
+        data-ouia-component-id="OUIA-Generated-TableRow-34"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
         <th
-          aria-sort="none"
-          class="pf-c-table__sort"
+          aria-sort="ascending"
+          class="pf-c-table__sort pf-m-selected"
           scope="col"
         >
           <button
@@ -6441,7 +6581,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
                   width="1em"
                 >
                   <path
-                    d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                    d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
                   />
                 </svg>
               </span>
@@ -6491,170 +6631,6 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
       class=""
       role="rowgroup"
     >
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-31"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-47"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              A
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-48"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          1
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-32"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-49"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              A
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-50"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          1
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-33"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-51"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              A
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-52"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          1
-        </td>
-      </tr>
-      <tr
-        class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-34"
-        data-ouia-component-type="PF4/TableRow"
-        data-ouia-safe="true"
-      >
-        <td
-          class=""
-          data-label="Name"
-        >
-          <div
-            class="pf-c-content"
-          >
-            <h3
-              class=""
-              data-ouia-component-id="OUIA-Generated-Text-53"
-              data-ouia-component-type="PF4/Text"
-              data-ouia-safe="true"
-              data-pf-content="true"
-            >
-              A
-              <br />
-              <small
-                class=""
-                data-ouia-component-id="OUIA-Generated-Text-54"
-                data-ouia-component-type="PF4/Text"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                letters
-              </small>
-            </h3>
-          </div>
-        </td>
-        <td
-          class=""
-          data-label="Quantity"
-        >
-          1
-        </td>
-      </tr>
       <tr
         class=""
         data-ouia-component-id="OUIA-Generated-TableRow-35"
@@ -6921,11 +6897,175 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
               data-ouia-safe="true"
               data-pf-content="true"
             >
-              Z
+              A
               <br />
               <small
                 class=""
                 data-ouia-component-id="OUIA-Generated-Text-68"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-42"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-69"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              A
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-70"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-43"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-71"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              A
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-72"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-44"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-73"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              A
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-74"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                letters
+              </small>
+            </h3>
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Quantity"
+        >
+          1
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-45"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h3
+              class=""
+              data-ouia-component-id="OUIA-Generated-Text-75"
+              data-ouia-component-type="PF4/Text"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              Z
+              <br />
+              <small
+                class=""
+                data-ouia-component-id="OUIA-Generated-Text-76"
                 data-ouia-component-type="PF4/Text"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -6949,7 +7089,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
     data-ouia-component-id="OUIA-Generated-Pagination-bottom-7"
     data-ouia-component-type="PF4/Pagination"
     data-ouia-safe="true"
-    id="pagination-options-menu-29"
+    id="pagination-options-menu-25"
     style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
   >
     <div
@@ -6984,7 +7124,7 @@ exports[`ProductsTable when using pagination can change per page 1`] = `
           data-ouia-component-id="OUIA-Generated-DropdownToggle-14"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe="true"
-          id="pagination-options-menu-toggle-30"
+          id="pagination-options-menu-toggle-26"
           type="button"
         >
           <span

--- a/src/pages/SubscriptionInventoryPage/SubscriptionInventoryPage.tsx
+++ b/src/pages/SubscriptionInventoryPage/SubscriptionInventoryPage.tsx
@@ -9,7 +9,7 @@ import { useQueryClient } from 'react-query';
 import { User } from '../../hooks/useUser';
 import ProductsTable from '../../components/ProductsTable';
 import { Processing } from '../../components/emptyState';
-import useProducts, { Product } from '../../hooks/useProducts';
+import useProducts from '../../hooks/useProducts';
 
 const SubscriptionInventoryPage: FunctionComponent = () => {
   const queryClient = useQueryClient();

--- a/src/pages/SubscriptionInventoryPage/SubscriptionInventoryPage.tsx
+++ b/src/pages/SubscriptionInventoryPage/SubscriptionInventoryPage.tsx
@@ -2,15 +2,19 @@ import React, { FunctionComponent } from 'react';
 import { Redirect, withRouter } from 'react-router-dom';
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import PageHeader from '@redhat-cloud-services/frontend-components/PageHeader';
+import Unavailable from '@redhat-cloud-services/frontend-components/Unavailable';
 import { PageSection, Title } from '@patternfly/react-core';
 import { PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { useQueryClient } from 'react-query';
 import { User } from '../../hooks/useUser';
 import ProductsTable from '../../components/ProductsTable';
+import { Processing } from '../../components/emptyState';
+import useProducts, { Product } from '../../hooks/useProducts';
 
 const SubscriptionInventoryPage: FunctionComponent = () => {
   const queryClient = useQueryClient();
   const user: User = queryClient.getQueryData('user');
+  const { isFetching, isLoading, error, data } = useProducts();
 
   const Page: FunctionComponent = () => {
     return (
@@ -21,7 +25,13 @@ const SubscriptionInventoryPage: FunctionComponent = () => {
         <Main>
           <PageSection variant="light">
             <Title headingLevel="h2">All subscriptions for account {user.accountNumber}</Title>
-            <ProductsTable />
+            <>
+              {isLoading && !error && <Processing />}
+
+              {!isLoading && !error && <ProductsTable data={data} isFetching={isFetching} />}
+
+              {error && <Unavailable />}
+            </>
           </PageSection>
         </Main>
       </>

--- a/src/pages/SubscriptionInventoryPage/__tests__/SubscriptionInventoryPage.test.tsx
+++ b/src/pages/SubscriptionInventoryPage/__tests__/SubscriptionInventoryPage.test.tsx
@@ -7,9 +7,11 @@ import { Provider } from 'react-redux';
 import { init } from '../../../store';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import useUser from '../../../hooks/useUser';
+import useProducts from '../../../hooks/useProducts';
 import { get, def } from 'bdd-lazy-var';
 
 jest.mock('../../../hooks/useUser');
+jest.mock('../../../hooks/useProducts');
 jest.mock('react-router-dom', () => ({
   ...(jest.requireActual('react-router-dom') as Record<string, unknown>),
   useLocation: () => ({
@@ -32,7 +34,6 @@ const PageContainer = () => (
 );
 
 const mockAuthenticateUser = (
-  isLoading: boolean,
   orgAdminStatus: boolean,
   isError: boolean,
   canReadProducts: boolean
@@ -44,7 +45,7 @@ const mockAuthenticateUser = (
     isSCACapable: true
   };
   (useUser as jest.Mock).mockReturnValue({
-    isLoading: isLoading,
+    isLoading: false,
     isFetching: false,
     isSuccess: true,
     isError: isError,
@@ -60,20 +61,21 @@ jest.mock('../../../components/ProductsTable', () => () => <div>Products Table</
 jest.mock('../../NoPermissionsPage', () => () => <div>Not Authorized</div>);
 
 describe('SubscriptionInventoryPage', () => {
-  def('isLoading', () => false);
-  def('isOrgAdmin', () => false);
-  def('isError', () => false);
+  def('orgAdmin', () => false);
+  def('userError', () => false);
   def('canReadProducts', () => true);
+  def('productsLoading', () => false);
+  def('productsError', () => false);
 
   beforeEach(() => {
     window.insights = {};
     jest.resetAllMocks();
-    mockAuthenticateUser(
-      get('isLoading'),
-      get('isOrgAdmin'),
-      get('isError'),
-      get('canReadProducts')
-    );
+    mockAuthenticateUser(get('orgAdmin'), get('userError'), get('canReadProducts'));
+    (useProducts as jest.Mock).mockReturnValue({
+      isLoading: get('productsLoading'),
+      error: get('productsError'),
+      data: []
+    });
   });
 
   it('renders correctly', async () => {
@@ -83,7 +85,7 @@ describe('SubscriptionInventoryPage', () => {
   });
 
   describe('when the user call fails', () => {
-    def('isError', () => true);
+    def('userError', () => true);
 
     it('renders an error message when user call fails', async () => {
       const { container } = render(<PageContainer />);
@@ -98,6 +100,26 @@ describe('SubscriptionInventoryPage', () => {
     it('redirects to not authorized page', async () => {
       const { container } = render(<PageContainer />);
       await waitFor(() => expect(useUser).toHaveBeenCalledTimes(1));
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('when the products call fails', () => {
+    def('productsError', () => true);
+
+    it('renders the error page', async () => {
+      const { container } = render(<PageContainer />);
+      await waitFor(() => expect(useProducts).toHaveBeenCalledTimes(1));
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('when the products are loading', () => {
+    def('productsLoading', () => true);
+
+    it('renders the loading component', async () => {
+      const { container } = render(<PageContainer />);
+      await waitFor(() => expect(useProducts).toHaveBeenCalledTimes(1));
       expect(container).toMatchSnapshot();
     });
   });

--- a/src/pages/SubscriptionInventoryPage/__tests__/__snapshots__/SubscriptionInventoryPage.test.tsx.snap
+++ b/src/pages/SubscriptionInventoryPage/__tests__/__snapshots__/SubscriptionInventoryPage.test.tsx.snap
@@ -42,6 +42,146 @@ exports[`SubscriptionInventoryPage renders correctly 1`] = `
 </div>
 `;
 
+exports[`SubscriptionInventoryPage when the products are loading renders the loading component 1`] = `
+<div>
+  <section
+    class="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+    widget-type="InsightsPageHeader"
+  >
+    <h1
+      class="pf-c-title pf-m-2xl"
+      data-ouia-component-id="OUIA-Generated-Title-4"
+      data-ouia-component-type="PF4/Title"
+      data-ouia-safe="true"
+      widget-type="InsightsPageHeaderTitle"
+    >
+       
+      Subscription Inventory
+       
+    </h1>
+  </section>
+  <section
+    class="pf-l-page__main-section pf-c-page__main-section"
+    page-type=""
+  >
+    <section
+      class="pf-c-page__main-section pf-m-light"
+    >
+      <h2
+        class="pf-c-title pf-m-xl"
+        data-ouia-component-id="OUIA-Generated-Title-5"
+        data-ouia-component-type="PF4/Title"
+        data-ouia-safe="true"
+      >
+        All subscriptions for account 
+        8675309
+      </h2>
+      <div
+        class="pf-l-bullseye"
+      >
+        <span
+          aria-valuetext="Loading..."
+          class="pf-c-spinner pf-m-xl"
+          role="progressbar"
+        >
+          <span
+            class="pf-c-spinner__clipper"
+          />
+          <span
+            class="pf-c-spinner__lead-ball"
+          />
+          <span
+            class="pf-c-spinner__tail-ball"
+          />
+        </span>
+      </div>
+    </section>
+  </section>
+</div>
+`;
+
+exports[`SubscriptionInventoryPage when the products call fails renders the error page 1`] = `
+<div>
+  <section
+    class="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+    widget-type="InsightsPageHeader"
+  >
+    <h1
+      class="pf-c-title pf-m-2xl"
+      data-ouia-component-id="OUIA-Generated-Title-1"
+      data-ouia-component-type="PF4/Title"
+      data-ouia-safe="true"
+      widget-type="InsightsPageHeaderTitle"
+    >
+       
+      Subscription Inventory
+       
+    </h1>
+  </section>
+  <section
+    class="pf-l-page__main-section pf-c-page__main-section"
+    page-type=""
+  >
+    <section
+      class="pf-c-page__main-section pf-m-light"
+    >
+      <h2
+        class="pf-c-title pf-m-xl"
+        data-ouia-component-id="OUIA-Generated-Title-2"
+        data-ouia-component-type="PF4/Title"
+        data-ouia-safe="true"
+      >
+        All subscriptions for account 
+        8675309
+      </h2>
+      <div
+        class="pf-c-empty-state pf-m-lg ins-c-empty-state__unavailable pf-m-redhat-font"
+      >
+        <div
+          class="pf-c-empty-state__content"
+        >
+          <svg
+            aria-hidden="true"
+            class="pf-c-empty-state__icon"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+            />
+          </svg>
+          <h5
+            class="pf-c-title pf-m-lg"
+            data-ouia-component-id="OUIA-Generated-Title-3"
+            data-ouia-component-type="PF4/Title"
+            data-ouia-safe="true"
+          >
+            This page is temporarily unavailable
+          </h5>
+          <div
+            class="pf-c-empty-state__body"
+          >
+            Try refreshing the page. If the problem persists, contact your organization administrator or visit our
+            <a
+              href="https://status.redhat.com/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+               status page
+            </a>
+             for known outages.
+          </div>
+        </div>
+      </div>
+    </section>
+  </section>
+</div>
+`;
+
 exports[`SubscriptionInventoryPage when the user call fails renders an error message when user call fails 1`] = `
 <div>
   <div


### PR DESCRIPTION
This adds a text search box to the top left of the table.  It searches for a match anywhere in name or product line.  A small x appears within the search box; this can be clicked to clear the search.

I also updated the page to default to sorting by name and replaced the uuid ouia hack with typescript ignore annotations.