### PR TITLE
Place hideGlobalFilter() call within a useEffect

### DIFF
--- a/src/components/Authentication/Authentication.tsx
+++ b/src/components/Authentication/Authentication.tsx
@@ -19,7 +19,9 @@ const Authentication: FC = ({ children }) => {
     queryClient.invalidateQueries('user');
   }, [location.pathname]);
 
-  isSuccess && window.insights?.chrome?.hideGlobalFilter();
+  useEffect(() => {
+    isSuccess && window.insights?.chrome?.hideGlobalFilter();
+  }, [isSuccess]);
 
   if (isError === true) {
     return <Unavailable />;


### PR DESCRIPTION
Due to changes in insights-chrome, we need to call this function within a useEffect in order to not have an infinite loop

To test that this works, load the app and refresh a few times.  On `main` you'll get an intermittent failure where you end up with a blank page.  On this branch, the page loads every time.