### PR TITLE
TEAMNADO-4958: Add useChrome hook

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -15,7 +15,48 @@ const toHaveLoader = (obj) => {
   }
 };
 
+let mocki = 0;
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  default: () => ({
+    hideGlobalFilter: jest.fn(),
+    updateDocumentTitle: jest.fn(),
+    auth: {
+      getToken: () => Promise.resolve('TOKEN'),
+      getUser: () =>
+        Promise.resolve({
+          identity: {
+            account_number: '0',
+            type: 'User',
+            user: {
+              is_org_admin: true,
+              email: 'john.doe@redhat.com'
+            }
+          },
+          entitlements: {
+            hybrid_cloud: { is_entitled: true },
+            insights: { is_entitled: true },
+            openshift: { is_entitled: true },
+            smart_management: { is_entitled: false }
+          }
+        })
+    },
+    appAction: jest.fn(),
+    appObjectId: jest.fn(),
+    on: jest.fn(),
+    getUserPermissions: () =>
+      Promise.resolve([{ resourceDefinitions: [], permission: 'subscriptions:products:read' }]),
+    getEnvironment: () => {
+      if (!mocki) {
+        mocki++;
+        return 'qa';
+      }
+      return null;
+    }
+  })
+}));
+
 expect.extend({
   toHaveLoader
 });
-

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import NotificationProvider from './contexts/NotificationProvider';
 import Notifications from './components/Notifications';
 import { useNavigate } from 'react-router-dom';
 import { getPartialRouteFromPath } from './utilities/routeHelpers';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -22,11 +23,11 @@ const queryClient = new QueryClient({
 
 const App = () => {
   const navigate = useNavigate();
-  useEffect(() => {
-    insights.chrome.init();
+  const chrome = useChrome();
 
-    insights.chrome.identifyApp('subscriptionInventory');
-    const unregister = insights.chrome.on('APP_NAVIGATION', (event) => {
+  useEffect(() => {
+    chrome.updateDocumentTitle('subscriptionInventory');
+    const unregister = chrome.on('APP_NAVIGATION', (event) => {
       const partialURL = getPartialRouteFromPath(event.domEvent.href);
       navigate(partialURL);
     });

--- a/src/components/Authentication/Authentication.tsx
+++ b/src/components/Authentication/Authentication.tsx
@@ -4,10 +4,12 @@ import { useLocation } from 'react-router-dom';
 import { Processing } from '../emptyState';
 import Unavailable from '@redhat-cloud-services/frontend-components/Unavailable';
 import useUser from '../../hooks/useUser';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const Authentication: FC = ({ children }) => {
   const queryClient = useQueryClient();
   const location = useLocation();
+  const chrome = useChrome();
 
   const { isLoading, isFetching, isSuccess, isError } = useUser();
 
@@ -20,7 +22,7 @@ const Authentication: FC = ({ children }) => {
   }, [location.pathname]);
 
   useEffect(() => {
-    isSuccess && window.insights?.chrome?.hideGlobalFilter();
+    isSuccess && chrome.hideGlobalFilter(true);
   }, [isSuccess]);
 
   if (isError === true) {

--- a/src/pages/DetailsPage/__tests__/DetailsPage.test.tsx
+++ b/src/pages/DetailsPage/__tests__/DetailsPage.test.tsx
@@ -98,7 +98,6 @@ const mockSingleProduct = (hasData: boolean) => {
 
 describe('Details Page', () => {
   it('loader shows correctly', async () => {
-    window.insights = {};
     const isLoading = true;
     const isOrgAdmin = true;
     mockAuthenticateUser(isLoading, isOrgAdmin, true);

--- a/src/pages/NoPermissionsPage/NoPermissionsPage.js
+++ b/src/pages/NoPermissionsPage/NoPermissionsPage.js
@@ -1,10 +1,13 @@
 import React, { useEffect } from 'react';
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const NoPermissionsPage = () => {
+  const chrome = useChrome();
+
   useEffect(() => {
-    insights?.chrome?.appAction?.('no-permissions');
+    chrome.appAction('no-permissions');
   }, []);
 
   return (

--- a/src/pages/NoPermissionsPage/__tests__/NoPermissionsPage.test.tsx
+++ b/src/pages/NoPermissionsPage/__tests__/NoPermissionsPage.test.tsx
@@ -46,7 +46,6 @@ const mockAuthenticateUser = (isLoading: boolean, orgAdminStatus: boolean) => {
 
 describe('No Permissions Page', () => {
   it('renders correctly', async () => {
-    window.insights = {};
     const isLoading = false;
     const isOrgAdmin = true;
     mockAuthenticateUser(isLoading, isOrgAdmin);

--- a/src/pages/NotFoundPage/NotFoundPage.js
+++ b/src/pages/NotFoundPage/NotFoundPage.js
@@ -1,10 +1,13 @@
 import React, { useEffect } from 'react';
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import NotFound from './NotFound';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const NotFoundPage = () => {
+  const chrome = useChrome();
+
   useEffect(() => {
-    window.insights?.chrome?.appAction?.('notFound-page');
+    chrome.appAction('notFound-page');
   }, []);
   return (
     <Main>

--- a/src/pages/NotFoundPage/__tests__/NotFoundPage.test.tsx
+++ b/src/pages/NotFoundPage/__tests__/NotFoundPage.test.tsx
@@ -46,7 +46,6 @@ const mockAuthenticateUser = (isLoading: boolean, orgAdminStatus: boolean) => {
 
 describe('Not Found Page', () => {
   it('renders correctly', async () => {
-    window.insights = {};
     const isLoading = false;
     const isOrgAdmin = true;
     mockAuthenticateUser(isLoading, isOrgAdmin);

--- a/src/pages/OopsPage/OopsPage.js
+++ b/src/pages/OopsPage/OopsPage.js
@@ -1,10 +1,13 @@
 import React, { useEffect } from 'react';
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import Unavailable from '@redhat-cloud-services/frontend-components/Unavailable';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const OopsPage = () => {
+  const chrome = useChrome();
+
   useEffect(() => {
-    insights?.chrome?.appAction?.('oops-page');
+    chrome.appAction('oops-page');
   }, []);
   return (
     <Main>

--- a/src/pages/OopsPage/__tests__/OopsPage.test.tsx
+++ b/src/pages/OopsPage/__tests__/OopsPage.test.tsx
@@ -46,7 +46,6 @@ const mockAuthenticateUser = (isLoading: boolean, orgAdminStatus: boolean) => {
 
 describe('Oops Page', () => {
   it('renders correctly', async () => {
-    window.insights = {};
     const isLoading = false;
     const isOrgAdmin = true;
     mockAuthenticateUser(isLoading, isOrgAdmin);

--- a/src/pages/SubscriptionInventoryPage/__tests__/SubscriptionInventoryPage.test.tsx
+++ b/src/pages/SubscriptionInventoryPage/__tests__/SubscriptionInventoryPage.test.tsx
@@ -80,7 +80,6 @@ describe('SubscriptionInventoryPage', () => {
   def('statusCardsError', () => false);
 
   beforeEach(() => {
-    window.insights = {};
     jest.resetAllMocks();
     mockAuthenticateUser(get('orgAdmin'), get('userError'), get('canReadProducts'));
     (useProducts as jest.Mock).mockReturnValue({

--- a/src/utilities/__tests__/platformServices.test.ts
+++ b/src/utilities/__tests__/platformServices.test.ts
@@ -1,47 +1,23 @@
-import {
-  authenticateUser,
-  getConfig,
-  getEnvironment,
-  getUserRbacPermissions
-} from '../platformServices';
-
-beforeEach(() => {
-  window.insights = {
-    chrome: {
-      auth: {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        getUser: () => {}
-      }
-    }
-  };
-});
+import { useAuthenticateUser, useEnvironment, useUserRbacPermissions } from '../platformServices';
 
 describe('Authenticate User method', () => {
-  it('should return a promise with user data', () => {
-    window.insights.chrome.auth.getUser = jest.fn().mockResolvedValue({
-      identity: {
-        user: {
-          email: 'john.doe@redhat.com'
-        }
-      }
-    });
-
-    expect(authenticateUser()).resolves.toEqual({
-      identity: {
-        user: {
-          email: 'john.doe@redhat.com'
-        }
-      }
-    });
+  it('should return a promise with user data', async () => {
+    const user = await useAuthenticateUser();
+    expect(user.identity.user.email).toEqual('john.doe@redhat.com');
   });
 
   it('should throw an error if rejected', () => {
-    window.insights.chrome.auth.getUser = jest.fn().mockImplementation(() => {
-      throw new Error('Error getting user');
-    });
+    jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+      __esModule: true,
+      default: () => ({
+        getUser: () => {
+          throw new Error('Error getting user');
+        }
+      })
+    }));
 
     try {
-      authenticateUser();
+      useAuthenticateUser();
     } catch (e) {
       expect(e.message).toEqual('Error authenticating user: Error getting user');
     }
@@ -50,22 +26,21 @@ describe('Authenticate User method', () => {
 
 describe('getUserRbacPermissions', () => {
   it('should return a promise with user RBAC permissions', () => {
-    window.insights.chrome.getUserPermissions = jest
-      .fn()
-      .mockResolvedValue([{ resourceDefinitions: [], permission: 'subscriptions:products:read' }]);
-
-    expect(getUserRbacPermissions()).resolves.toEqual([
+    expect(useUserRbacPermissions()).resolves.toEqual([
       { resourceDefinitions: [], permission: 'subscriptions:products:read' }
     ]);
   });
 
   it('should throw an error if rejected', () => {
-    window.insights.chrome.getUserPermissions = jest.fn().mockImplementation(() => {
-      throw new Error('Nope');
-    });
+    jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+      __esModule: true,
+      default: () => ({
+        getUserPermissions: () => 'Nope'
+      })
+    }));
 
     try {
-      authenticateUser();
+      useAuthenticateUser();
     } catch (e) {
       expect(e.message).toEqual('Error getting user permissions: Nope');
     }
@@ -74,12 +49,18 @@ describe('getUserRbacPermissions', () => {
 
 describe('getEnvironment', () => {
   it('returns the environment', () => {
-    window.insights.chrome.getEnvironment = jest.fn().mockReturnValue('qa');
-    expect(getEnvironment()).toEqual('qa');
+    expect(useEnvironment()).toEqual('qa');
   });
 
   it('returns "ci" if environment is not specified', () => {
-    window.insights.chrome.getEnvironment = jest.fn().mockReturnValue(null);
-    expect(getEnvironment()).toEqual('ci');
+    jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+      __esModule: true,
+      default: () => ({
+        getEnvironment: () => {
+          return;
+        }
+      })
+    }));
+    expect(useEnvironment()).toEqual('ci');
   });
 });


### PR DESCRIPTION
This changes all instances of window.insights.chrome to useChrome() since the chroming via the window has been deprecated.

It also adds a useToken hook, so that if the underlying implementation changes we can update just the one place.