### PR TITLE
TEAMNADO-5720: Remove `BrowserRouter` and `APP_NAVIGATION` listener

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -25,7 +25,12 @@ plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({
     root: resolve(__dirname, '../'),
     moduleName: 'subscriptionInventory',
-    useFileHash: false
+    useFileHash: false,
+    shared: [
+      {
+        'react-router-dom': { singleton: true, requiredVersion: '*' }
+      }
+    ]
   })
 );
 

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -12,7 +12,12 @@ const { config: webpackConfig, plugins } = config({
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')({
     root: resolve(__dirname, '../'),
-    moduleName: 'subscriptionInventory'
+    moduleName: 'subscriptionInventory',
+    shared: [
+      {
+        'react-router-dom': { singleton: true, requiredVersion: '*' }
+      }
+    ]
   })
 );
 

--- a/src/App.js
+++ b/src/App.js
@@ -5,8 +5,6 @@ import './App.scss';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import NotificationProvider from './contexts/NotificationProvider';
 import Notifications from './components/Notifications';
-import { useNavigate } from 'react-router-dom';
-import { getPartialRouteFromPath } from './utilities/routeHelpers';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const queryClient = new QueryClient({
@@ -22,18 +20,10 @@ const queryClient = new QueryClient({
 });
 
 const App = () => {
-  const navigate = useNavigate();
   const chrome = useChrome();
 
   useEffect(() => {
     chrome.updateDocumentTitle('subscriptionInventory');
-    const unregister = chrome.on('APP_NAVIGATION', (event) => {
-      const partialURL = getPartialRouteFromPath(event.domEvent.href);
-      navigate(partialURL);
-    });
-    return () => {
-      unregister();
-    };
   }, []);
 
   return (

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,20 +1,11 @@
 import React from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { init } from './store';
 import App from './App';
-import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 
 const AppEntry = ({ logger }) => (
   <Provider store={(logger ? init(logger) : init()).getStore()}>
-    <Router
-      basename={`${getBaseName(
-        window.location.pathname,
-        location.href.includes('insights') ? 3 : 2
-      )}`}
-    >
-      <App />
-    </Router>
+    <App />
   </Provider>
 );
 

--- a/src/components/ProductsTable/ProductsTable.tsx
+++ b/src/components/ProductsTable/ProductsTable.tsx
@@ -215,7 +215,7 @@ const ProductsTable: FunctionComponent<ProductsTableProps> = ({
                 <Td dataLabel={columnNames.name}>
                   <TextContent>
                     <Text component={TextVariants.h3}>
-                      <Link to={`/${datum.sku}`}>{datum.name}</Link>
+                      <Link to={`${datum.sku}`}>{datum.name}</Link>
                       <br />
                       <Text component={TextVariants.small}>{datum.productLine}</Text>
                     </Text>

--- a/src/pages/DetailsPage/DetailsPage.tsx
+++ b/src/pages/DetailsPage/DetailsPage.tsx
@@ -46,7 +46,7 @@ const DetailsPage: FunctionComponent = () => {
         {!isLoading && !error && (
           <>
             <Breadcrumb>
-              <BreadcrumbItem render={() => <Link to="/">Subscriptions Inventory</Link>} />
+              <BreadcrumbItem render={() => <Link to="../">Subscriptions Inventory</Link>} />
               <BreadcrumbItem isActive>{data.name} </BreadcrumbItem>
             </Breadcrumb>
             <PageHeaderTitle title={data.name} />


### PR DESCRIPTION
These two pieces of code are removed as part of the platform's upgrade to React Router v6.