### PR TITLE
Subscriptions widget styling updates

### DIFF
--- a/src/components/Widgets/SubscriptionsWidget.scss
+++ b/src/components/Widgets/SubscriptionsWidget.scss
@@ -2,19 +2,49 @@
 @import '~@redhat-cloud-services/frontend-components-utilities/styles/_all';
 
 .pf-v5-l-gallery {
-  container-type: inline-size;
-  flex-wrap: wrap;
-  .pf-v5-c-alert {
-    white-space: nowrap;
-    padding-bottom: var(--pf-global--spacer--xl);
-  }
-  @container (width < 500px) {
-    .pf-v5-c-alert {
-      padding-top: var(--pf-global--spacer--sm);
-      padding-bottom: var(--pf-global--spacer--md);
-    }
+  height: 100%;
+  --pf-v5-l-gallery--GridTemplateColumns--min: 20%;
+  padding: var(--pf-global--spacer--md);
+}
+@container (width < 700px) {
+  .pf-v5-l-gallery {
+    --pf-v5-l-gallery--GridTemplateColumns--min: 40%;
   }
 }
+
+.alert-link {
+  height: 100%;
+  text-decoration: none;
+}
+.pf-v5-c-alert {
+  display: flex;
+  align-items: center; // Vertical Alignment
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  .pf-v5-c-alert__icon {
+    margin-bottom: var(--pf-global--spacer--md);
+    margin-right: 0;
+    .pf-v5-svg {
+      margin-left: auto;
+      margin-right: auto;
+      font-size: 30px;
+    }
+  }
+  .pf-v5-c-alert__title {
+    vertical-align: middle;
+    text-align: center;
+    font-size: 14px;
+    font-weight: medium;
+  }
+  .pf-v5-c-alert__description {
+    text-align: center;
+    font-size: var(--pf-v5-global--FontSize--md);
+    font-weight: medium;
+    margin-top: 5px;
+  }
+}
+
 .pf-v5-c-empty-state {
   padding: var(--pf-global--spacer--md);
   &__icon {

--- a/src/components/Widgets/SubscriptionsWidget.tsx
+++ b/src/components/Widgets/SubscriptionsWidget.tsx
@@ -14,6 +14,7 @@ import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import { AlertVariant } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import { Gallery } from '@patternfly/react-core/dist/dynamic/layouts/Gallery';
 import { Link } from 'react-router-dom';
+
 import EmptyStateSubscriptionsIcon from './public/images/SubscriptionsWidgetEmptyStateIcon';
 import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
 

--- a/src/components/Widgets/SubscriptionsWidget.tsx
+++ b/src/components/Widgets/SubscriptionsWidget.tsx
@@ -29,15 +29,15 @@ const SubscriptionsWidget = () => {
 const cardData = {
   active: {
     title: 'Active',
-    variant: 'success'
+    variant: AlertVariant.success
   },
   expiringSoon: {
     title: 'Expiring soon',
-    variant: 'warning'
+    variant: AlertVariant.warning
   },
   expired: {
     title: 'Expired',
-    variant: 'danger'
+    variant: AlertVariant.danger
   },
   futureDated: {
     title: 'Future dated',

--- a/src/components/Widgets/SubscriptionsWidget.tsx
+++ b/src/components/Widgets/SubscriptionsWidget.tsx
@@ -3,20 +3,21 @@ import OutlinedCalendarAltIcon from '@patternfly/react-icons/dist/js/icons/outli
 import useStatus from '../../hooks/useStatus';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import './SubscriptionsWidget.scss';
-import { EmptyState } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
-import { EmptyStateVariant } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
-import { EmptyStateBody } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
-import { Stack } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
-import { StackItem } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
-import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
-import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
-import { AlertVariant } from '@patternfly/react-core/dist/dynamic/components/Alert';
-import { Gallery } from '@patternfly/react-core/dist/dynamic/layouts/Gallery';
+import {
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Stack,
+  StackItem,
+  Title,
+  Alert,
+  AlertVariant,
+  Gallery
+} from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
-
 import EmptyStateSubscriptionsIcon from './public/images/SubscriptionsWidgetEmptyStateIcon';
-import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
+import { Spinner } from '@patternfly/react-core';
 
 const queryClient = new QueryClient();
 

--- a/src/components/Widgets/SubscriptionsWidget.tsx
+++ b/src/components/Widgets/SubscriptionsWidget.tsx
@@ -11,6 +11,7 @@ import { Stack } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
 import { StackItem } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
 import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
 import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
+import { AlertVariant } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import { Gallery } from '@patternfly/react-core/dist/dynamic/layouts/Gallery';
 import { Link } from 'react-router-dom';
 import EmptyStateSubscriptionsIcon from './public/images/SubscriptionsWidgetEmptyStateIcon';
@@ -58,7 +59,7 @@ const SubsWidget = () => {
   return (
     <div className="subscription-inventory">
       {isCardDataEmpty ? (
-        <EmptyState variant={EmptyStateVariant.large}>
+        <EmptyState variant={EmptyStateVariant.lg}>
           <EmptyStateIcon icon={EmptyStateSubscriptionsIcon} />
           <Title headingLevel="h4" size="lg">
             No connected subscriptions

--- a/src/components/Widgets/SubscriptionsWidget.tsx
+++ b/src/components/Widgets/SubscriptionsWidget.tsx
@@ -3,20 +3,18 @@ import OutlinedCalendarAltIcon from '@patternfly/react-icons/dist/js/icons/outli
 import useStatus from '../../hooks/useStatus';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import './SubscriptionsWidget.scss';
-import {
-  EmptyState,
-  EmptyStateVariant,
-  EmptyStateIcon,
-  EmptyStateBody,
-  Stack,
-  StackItem,
-  Title,
-  Alert,
-  Gallery
-} from '@patternfly/react-core';
+import { EmptyState } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateVariant } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateIcon } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateBody } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { Stack } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
+import { StackItem } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
+import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
+import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
+import { Gallery } from '@patternfly/react-core/dist/dynamic/layouts/Gallery';
 import { Link } from 'react-router-dom';
 import EmptyStateSubscriptionsIcon from './public/images/SubscriptionsWidgetEmptyStateIcon';
-import { Spinner } from '@patternfly/react-core';
+import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
 
 const queryClient = new QueryClient();
 
@@ -74,17 +72,13 @@ const SubsWidget = () => {
           </EmptyStateBody>
         </EmptyState>
       ) : (
-        <Gallery
-          hasGutter
-          className="pf-v5-u-p-md"
-          style={{ display: 'flex', flexDirection: 'row' }}
-        >
+        <Gallery hasGutter>
           {['active', 'expiringSoon', 'expired', 'futureDated'].map(
             (name: keyof typeof cardData) => {
               return (
                 <Link
                   to="/subscriptions/inventory"
-                  style={{ flex: 1, textDecoration: 'none' }}
+                  className="alert-link"
                   rel="noopener noreferrer"
                   target="_blank"
                   key={name}


### PR DESCRIPTION
Depends on: https://github.com/RedHatInsights/widget-layout/pull/97

[RHCLOUD-32808](https://issues.redhat.com/browse/RHCLOUD-32808)

Old
<img width="1335" alt="Screenshot 2024-06-24 at 9 49 02 AM" src="https://github.com/RedHatInsights/subscription-inventory-ui/assets/1287144/18034145-4948-4595-9085-3ef5cb4ffec0">

New
<img width="1332" alt="Screenshot 2024-06-24 at 9 48 03 AM" src="https://github.com/RedHatInsights/subscription-inventory-ui/assets/1287144/3f4884e7-d359-4d67-ab90-30ccb3272ae8">