### PR TITLE
TUSC-83: Add virt limit to product details page

### DIFF
--- a/src/components/ExportSubscriptions/ExportSubscriptions.tsx
+++ b/src/components/ExportSubscriptions/ExportSubscriptions.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import useExportSubscriptions from '../../hooks/useExportSubscriptions';
 import ExportIcon from '@patternfly/react-icons/dist/js/icons/export-icon';
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip } from '@patternfly/react-core/dist/dynamic/components/Tooltip';
 import useNotifications from '../../hooks/useNotifications';
 
 const ExportSubscriptions = () => {

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -1,11 +1,19 @@
 import React, { FC, ReactNode } from 'react';
-import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
+import { Button, ButtonProps } from '@patternfly/react-core/dist/dynamic/components/Button';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 interface ExternalLinkProps {
   children: ReactNode | string;
   href: string;
-  variant?: string;
+  variant?:
+    | 'link'
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'danger'
+    | 'warning'
+    | 'plain'
+    | 'control';
 }
 
 const ExternalLink: FC<ExternalLinkProps> = ({ children, href, variant = 'link' }) => {

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode } from 'react';
-import { Button } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 interface ExternalLinkProps {

--- a/src/components/GettingStartedCard/GettingStartedCard.tsx
+++ b/src/components/GettingStartedCard/GettingStartedCard.tsx
@@ -1,18 +1,16 @@
 import React, { FunctionComponent, useState } from 'react';
-import {
-  Button,
-  Card,
-  CardHeader,
-  CardTitle,
-  CardBody,
-  CardExpandableContent,
-  Flex,
-  Grid,
-  Label,
-  Level,
-  List,
-  ListItem
-} from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
+import { Card } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { CardHeader } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { CardTitle } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { CardBody } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { CardExpandableContent } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { Flex } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
+import { Grid } from '@patternfly/react-core/dist/dynamic/layouts/Grid';
+import { Label } from '@patternfly/react-core/dist/dynamic/components/Label';
+import { Level } from '@patternfly/react-core/dist/dynamic/layouts/Level';
+import { List } from '@patternfly/react-core/dist/dynamic/components/List';
+import { ListItem } from '@patternfly/react-core/dist/dynamic/components/List';
 import ExternalLink from '../ExternalLink';
 import ArrowRightIcon from '@patternfly/react-icons/dist/js/icons/arrow-right-icon';
 import ClipboardCheckIcon from '@patternfly/react-icons/dist/js/icons/clipboard-check-icon';

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -1,5 +1,7 @@
 import React, { FC } from 'react';
-import { Alert, AlertActionCloseButton, AlertGroup } from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
+import { AlertActionCloseButton } from '@patternfly/react-core/dist/dynamic/components/Alert';
+import { AlertGroup } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import useNotifications from '../../hooks/useNotifications';
 
 const Notifications: FC = () => {

--- a/src/components/PurchaseModal/PurchaseModal.tsx
+++ b/src/components/PurchaseModal/PurchaseModal.tsx
@@ -1,18 +1,16 @@
 import React, { FunctionComponent, useState } from 'react';
-import {
-  Button,
-  Card,
-  CardBody,
-  CardFooter,
-  CardTitle,
-  Flex,
-  FlexItem,
-  Grid,
-  GridItem,
-  Modal,
-  ModalVariant,
-  Title
-} from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
+import { Card } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { CardBody } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { CardFooter } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { CardTitle } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { Flex } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
+import { FlexItem } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
+import { Grid } from '@patternfly/react-core/dist/dynamic/layouts/Grid';
+import { GridItem } from '@patternfly/react-core/dist/dynamic/layouts/Grid';
+import { Modal } from '@patternfly/react-core/dist/dynamic/components/Modal';
+import { ModalVariant } from '@patternfly/react-core/dist/dynamic/components/Modal';
+import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
 import ExternalLink from '../ExternalLink';
 import onlineIcon from './onlineIcon.svg';
 import salesIcon from './salesIcon.svg';

--- a/src/components/SubscriptionTable/SubscriptionTable.tsx
+++ b/src/components/SubscriptionTable/SubscriptionTable.tsx
@@ -1,6 +1,9 @@
-import { Flex, FlexItem, Pagination, PaginationVariant } from '@patternfly/react-core';
+import { Flex } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
+import { FlexItem } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
+import { Pagination } from '@patternfly/react-core/dist/dynamic/components/Pagination';
+import { PaginationVariant } from '@patternfly/react-core/dist/dynamic/components/Pagination';
 import { NoSearchResults } from '../emptyState';
-import { SearchInput } from '@patternfly/react-core';
+import { SearchInput } from '@patternfly/react-core/dist/dynamic/components/SearchInput';
 import {
   Table /* data-codemods */,
   Tbody,

--- a/src/components/emptyState/NoSearchResults.tsx
+++ b/src/components/emptyState/NoSearchResults.tsx
@@ -1,13 +1,11 @@
 import React, { FunctionComponent } from 'react';
-import {
-  Button,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  EmptyStateVariant,
-  EmptyStateHeader,
-  EmptyStateFooter
-} from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
+import { EmptyState } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateBody } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateIcon } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateVariant } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateHeader } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateFooter } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 
 interface NoSearchResultsProps {

--- a/src/components/emptyState/Processing.tsx
+++ b/src/components/emptyState/Processing.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Bullseye } from '@patternfly/react-core/dist/dynamic/layouts/Bullseye';
+import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
 
 const Processing: FC = () => {
   return (

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -10,6 +10,7 @@ type Product = {
   serviceType: string;
   capacity: Capacity;
   subscriptions?: Subscription[];
+  virtLimit?: string;
 };
 
 type Subscription = {

--- a/src/pages/DetailsPage/DetailsPage.tsx
+++ b/src/pages/DetailsPage/DetailsPage.tsx
@@ -20,6 +20,7 @@ import Section from '@redhat-cloud-services/frontend-components/Section';
 import { Popover } from '@patternfly/react-core/dist/dynamic/components/Popover';
 import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
+import ExternalLink from '../../components/ExternalLink';
 
 const DetailsPage: FunctionComponent = () => {
   const { SKU } = useParams<{ SKU: string }>();
@@ -91,9 +92,7 @@ const DetailsPage: FunctionComponent = () => {
                         value, usage of the virt-who utility is required for proper subscription
                         reporting. Learn more about working with virtual machines and
                         hypervisor-based subscriptions.{' '}
-                        <a href={docsLink} target="_blank" rel="noreferrer">
-                          <ExternalLinkAltIcon />
-                        </a>
+                        <ExternalLink href={docsLink}> </ExternalLink>
                       </p>
                     }
                   >

--- a/src/pages/DetailsPage/DetailsPage.tsx
+++ b/src/pages/DetailsPage/DetailsPage.tsx
@@ -1,12 +1,10 @@
-import {
-  Badge,
-  Breadcrumb,
-  BreadcrumbItem,
-  List,
-  ListItem,
-  PageSection,
-  Title
-} from '@patternfly/react-core';
+import { Badge } from '@patternfly/react-core/dist/dynamic/components/Badge';
+import { Breadcrumb } from '@patternfly/react-core/dist/dynamic/components/Breadcrumb';
+import { BreadcrumbItem } from '@patternfly/react-core/dist/dynamic/components/Breadcrumb';
+import { List } from '@patternfly/react-core/dist/dynamic/components/List';
+import { ListItem } from '@patternfly/react-core/dist/dynamic/components/List';
+import { PageSection } from '@patternfly/react-core/dist/dynamic/components/Page';
+import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
 import PageHeader, { PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import React, { FunctionComponent, useEffect } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
@@ -19,6 +17,9 @@ import { User } from '../../hooks/useUser';
 import SubscriptionTable from '../../components/SubscriptionTable';
 import { HttpError } from '../../utilities/errors';
 import Section from '@redhat-cloud-services/frontend-components/Section';
+import { Popover } from '@patternfly/react-core/dist/dynamic/components/Popover';
+import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 const DetailsPage: FunctionComponent = () => {
   const { SKU } = useParams<{ SKU: string }>();
@@ -28,6 +29,8 @@ const DetailsPage: FunctionComponent = () => {
   const { isLoading, error, data } = useSingleProduct(SKU);
   const missingText = 'Not Available';
   const redirectRoute = '../no-permissions';
+  const docsLink =
+    'https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-config-vm-sub_';
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -74,6 +77,31 @@ const DetailsPage: FunctionComponent = () => {
                 ) : (
                   <>Not Available</>
                 )}
+              </ListItem>
+              <ListItem className="pf-v5-u-mt-0">
+                <b>
+                  Virtual Guest Limit{' '}
+                  <Popover
+                    aria-label="Learn more about Virtual Guest Limit"
+                    bodyContent={
+                      <p>
+                        The maximum number of virtual machines that can run on a system at no
+                        additional cost if the system using this subscription is deployed as a
+                        hypervisor to host virtual machines. When this field displays a non-zero
+                        value, usage of the virt-who utility is required for proper subscription
+                        reporting. Learn more about working with virtual machines and
+                        hypervisor-based subscriptions.{' '}
+                        <a href={docsLink} target="_blank" rel="noreferrer">
+                          <ExternalLinkAltIcon />
+                        </a>
+                      </p>
+                    }
+                  >
+                    <QuestionCircleIcon onClick={(e) => e.stopPropagation()} />
+                  </Popover>
+                  :{' '}
+                </b>
+                {data.virtLimit != undefined && data.virtLimit != '' ? data.virtLimit : missingText}
               </ListItem>
             </List>
           </>

--- a/src/pages/DetailsPage/__tests__/DetailsPage.test.tsx
+++ b/src/pages/DetailsPage/__tests__/DetailsPage.test.tsx
@@ -78,7 +78,8 @@ const mockSingleProduct = (hasData: boolean) => {
             startDate: '2021-10-24T04:00:00.000Z'
           }
         ]
-      : []
+      : [],
+    virtLimit: hasData ? 'TEST VirtLimit' : null
   };
 
   (useSingleProduct as jest.Mock).mockReturnValue({

--- a/src/pages/NoPermissionsPage/NoPermissionsPage.js
+++ b/src/pages/NoPermissionsPage/NoPermissionsPage.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import NotAuthorized from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import { PageSection } from '@patternfly/react-core';
+import { PageSection } from '@patternfly/react-core/dist/dynamic/components/Page';
 
 const NoPermissionsPage = () => {
   const chrome = useChrome();

--- a/src/pages/NotFoundPage/NotFound.tsx
+++ b/src/pages/NotFoundPage/NotFound.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import {
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  EmptyStateVariant,
-  EmptyStateHeader,
-  EmptyStateFooter
-} from '@patternfly/react-core';
-import { WrenchIcon } from '@patternfly/react-icons';
-import { Button } from '@patternfly/react-core';
+import { EmptyState } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateBody } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateIcon } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateVariant } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateHeader } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { EmptyStateFooter } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import WrenchIcon from '@patternfly/react-icons/dist/dynamic/icons/wrench-icon';
+import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import { useNavigate } from 'react-router-dom';
 
 const NotFound: React.FC = () => {

--- a/src/pages/NotFoundPage/NotFoundPage.js
+++ b/src/pages/NotFoundPage/NotFoundPage.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import NotFound from './NotFound';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import { PageSection } from '@patternfly/react-core';
+import { PageSection } from '@patternfly/react-core/dist/dynamic/components/Page';
 
 const NotFoundPage = () => {
   const chrome = useChrome();

--- a/src/pages/OopsPage/OopsPage.js
+++ b/src/pages/OopsPage/OopsPage.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import Unavailable from '@redhat-cloud-services/frontend-components/Unavailable';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import { PageSection } from '@patternfly/react-core';
+import { PageSection } from '@patternfly/react-core/dist/dynamic/components/Page';
 
 const OopsPage = () => {
   const chrome = useChrome();


### PR DESCRIPTION
This adds virt limit, along with its relevant helper text, to the product details page.

I also ran npm lint:js:fix, which explains most of these import changes. I don't think we've run it in this application since the import rule changed. The only changed relevant to this PR are in src/pages/DetailsPage/DetailsPage.tsx