### PR TITLE
add widget test page

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -2,25 +2,36 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import React, { Suspense, lazy } from 'react';
 import { Processing } from './components/emptyState';
 import Authentication from './components/Authentication';
+import useFeatureFlag from './hooks/useFeatureFlag';
+import { SubsWidget } from './components/Widgets/SubscriptionsWidget';
 
 const SubscriptionInventoryPage = lazy(() => import('./pages/SubscriptionInventoryPage'));
 const OopsPage = lazy(() => import('./pages/OopsPage'));
 const NoPermissionsPage = lazy(() => import('./pages/NoPermissionsPage'));
 const DetailsPage = lazy(() => import('./pages/DetailsPage'));
 
-export const InventoryRoutes: React.FC = () => (
-  <div className="inventory">
-    <Suspense fallback={<Processing />}>
-      <Authentication>
-        <Routes>
-          <Route path="/" element={<SubscriptionInventoryPage />} />
-          <Route path="/oops" element={<OopsPage />} />
-          <Route path="/no-permissions" element={<NoPermissionsPage />} />
-          <Route path="/:SKU" element={<DetailsPage />} />
-          {/* Finally, catch all unmatched routes */}
-          <Route path="*" element={<Navigate to="/oops" replace />} />
-        </Routes>
-      </Authentication>
-    </Suspense>
-  </div>
-);
+export const InventoryRoutes: React.FC = () => {
+  const shouldShowWidgetTest = useFeatureFlag('subscription-inventory.show-test-widget');
+
+  return (
+    <div className="inventory">
+      <Suspense fallback={<Processing />}>
+        <Authentication>
+          <Routes>
+            <Route path="/" element={<SubscriptionInventoryPage />} />
+            <Route path="/oops" element={<OopsPage />} />
+            <Route path="/no-permissions" element={<NoPermissionsPage />} />
+            <Route path="/:SKU" element={<DetailsPage />} />
+
+            {(shouldShowWidgetTest || false) && (
+              <Route path="/widget-test" element={<SubsWidget />} />
+            )}
+
+            {/* Finally, catch all unmatched routes */}
+            <Route path="*" element={<Navigate to="/oops" replace />} />
+          </Routes>
+        </Authentication>
+      </Suspense>
+    </div>
+  );
+};

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -23,9 +23,7 @@ export const InventoryRoutes: React.FC = () => {
             <Route path="/no-permissions" element={<NoPermissionsPage />} />
             <Route path="/:SKU" element={<DetailsPage />} />
 
-            {(shouldShowWidgetTest || false) && (
-              <Route path="/widget-test" element={<SubsWidget />} />
-            )}
+            {shouldShowWidgetTest && <Route path="/widget-test" element={<SubsWidget />} />}
 
             {/* Finally, catch all unmatched routes */}
             <Route path="*" element={<Navigate to="/oops" replace />} />

--- a/src/components/Widgets/SubscriptionsWidget.tsx
+++ b/src/components/Widgets/SubscriptionsWidget.tsx
@@ -11,7 +11,7 @@ import { StackItem } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
 import { Alert } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import { AlertVariant } from '@patternfly/react-core/dist/dynamic/components/Alert';
 import { Gallery } from '@patternfly/react-core/dist/dynamic/layouts/Gallery';
-import { Link } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
 import EmptyStateSubscriptionsIcon from './public/images/SubscriptionsWidgetEmptyStateIcon';
 
@@ -41,7 +41,7 @@ const cardData = {
     customIcon: <OutlinedCalendarAltIcon />
   }
 };
-const SubsWidget = () => {
+export const SubsWidget = () => {
   const statusCardData = useStatus();
   const isCardDataEmpty = useMemo(
     () =>
@@ -52,6 +52,7 @@ const SubsWidget = () => {
   );
   return (
     <div className="subscription-inventory">
+      <Navigate to="/" />
       {isCardDataEmpty ? (
         <EmptyState
           variant={EmptyStateVariant.lg}

--- a/src/components/Widgets/SubscriptionsWidget.tsx
+++ b/src/components/Widgets/SubscriptionsWidget.tsx
@@ -52,7 +52,6 @@ export const SubsWidget = () => {
   );
   return (
     <div className="subscription-inventory">
-      <Navigate to="/" />
       {isCardDataEmpty ? (
         <EmptyState
           variant={EmptyStateVariant.lg}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new widget test page for subscriptions inventory, conditionally enabled by the `subscription-inventory.show-test-widget` feature flag

New Features:
- Add a conditional `/widget-test` route for the SubscriptionsWidget component behind a feature flag

Enhancements:
- Export the `SubsWidget` component to enable its rendering outside its module