### PR TITLE
TUSC-248 and TUSC-270: Fix widget padding and purchase modal spacing

### DIFF
--- a/src/components/PurchaseModal/PurchaseModal.tsx
+++ b/src/components/PurchaseModal/PurchaseModal.tsx
@@ -85,8 +85,9 @@ const PurchaseModal: FunctionComponent = () => {
         onClose={handleToggle}
         title="Purchase Subscriptions"
         variant={ModalVariant.medium}
+        className="pf-v6-u-p-lg"
       >
-        <Grid hasGutter>
+        <Grid hasGutter className="pf-v6-u-m-0">
           <GridItem span={12}>
             <SectionHeading icon={onlineIcon} title="Online" />
           </GridItem>

--- a/src/components/Widgets/SubscriptionsWidget.scss
+++ b/src/components/Widgets/SubscriptionsWidget.scss
@@ -4,7 +4,6 @@
 .pf-v6-l-gallery {
   height: calc(100% - 36px);
   --pf-v6-l-gallery--GridTemplateColumns--min: 20%;
-  padding: var(--pf-t--global--spacer--md);
   margin: 16px;
 }
 


### PR DESCRIPTION
TUSC-248:

This removes an extra level of padding in the subscriptions widget that was added as part of the Patternfly 6 migration. Visit /widget-test to view these changes, or in a deployed environment view it on the dashboard.

TUSC-270:

This fixes some spacing issues in the purchase modal that appeared during the Patternfly 6 migration. This just adds padding to the grid component which is the main content in the modal, and then removes the margin-right that was on the modal as its handled by the inner padding now.