### PR TITLE
fix(subs-widget): ensure styling is working with FEO based registry

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -14,6 +14,7 @@ module.exports = {
       IS_DEV: process.env.NODE_ENV === 'development'
     })
   ],
+  sassPrefix: '.subscription-inventory, .subscriptionInventory',
   hotReload: process.env.HOT === 'true',
   ...(process.env.port ? { port: parseInt(process.env.port) } : {}),
   moduleFederation: {

--- a/src/components/Widgets/SubscriptionsWidget.scss
+++ b/src/components/Widgets/SubscriptionsWidget.scss
@@ -1,61 +1,70 @@
 // Importing Global Variables
 @import '@patternfly/patternfly/sass-utilities/index';
 
-.pf-v6-l-gallery {
-  height: calc(100% - 36px);
-  --pf-v6-l-gallery--GridTemplateColumns--min: 20%;
-  margin: 16px;
-}
-
-@container (width < 700px) {
+.subscription-inventory-widget {
+  container-name: subscriptions-widget;
+  container-type: inline-size;
+  height: 100%;
   .pf-v6-l-gallery {
-    --pf-v6-l-gallery--GridTemplateColumns--min: 40%;
+    height: calc(100% - 36px);
+    margin: 16px;
   }
-}
 
-.alert-link {
-  height: 100%;
-  text-decoration: none;
-}
+  .alert-link {
+    height: 100%;
+    text-decoration: none;
+  }
 
-.pf-v6-c-alert {
-  display: flex;
-  align-items: center; // Vertical Alignment
-  flex-direction: column;
-  height: 100%;
-  justify-content: center;
-  .pf-v6-c-alert__icon {
-    margin-bottom: var(--pf-t-global--spacer--md);
-    margin-right: 0;
-    .pf-v6-svg {
-      margin-left: auto;
-      margin-right: auto;
-      font-size: 30px;
+  .pf-v6-c-alert {
+    display: flex;
+    align-items: center; // Vertical Alignment
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    .pf-v6-c-alert__icon {
+      margin-bottom: var(--pf-t-global--spacer--md);
+      margin-right: 0;
+      .pf-v6-svg {
+        margin-left: auto;
+        margin-right: auto;
+        font-size: 30px;
+      }
+    }
+
+    .pf-v6-c-alert__title {
+      vertical-align: middle;
+      text-align: center;
+      font-size: 14px;
+      font-weight: medium;
+    }
+
+    .pf-v6-c-alert__description {
+      text-align: center;
+      font-size: var(--pf-t--global--spacer--md);
+      font-weight: 500;
+      margin-top: 5px;
     }
   }
 
-  .pf-v6-c-alert__title {
-    vertical-align: middle;
-    text-align: center;
-    font-size: 14px;
-    font-weight: medium;
-  }
-
-  .pf-v6-c-alert__description {
-    text-align: center;
-    font-size: var(--pf-t--global--spacer--md);
-    font-weight: 500;
-    margin-top: 5px;
+  .pf-v6-c-empty-state {
+    height: 100%;
+    padding: var(--pf-t--global--spacer--md);
+    &__icon {
+      margin-bottom: 0;
+    }
+    &__body {
+      margin-top: var(--pf-t--global--spacer--sm);
+    }
   }
 }
 
-.pf-v6-c-empty-state {
-  height: 100%;
-  padding: var(--pf-t--global--spacer--md);
-  &__icon {
-    margin-bottom: 0;
+@container subscriptions-widget (width >= 700px) {
+  .pf-v6-l-gallery {
+    --pf-v6-l-gallery--GridTemplateColumns--min: 20%;
   }
-  &__body {
-    margin-top: var(--pf-t--global--spacer--sm);
+}
+@container subscriptions-widget (width < 700px) {
+  .pf-v6-l-gallery {
+    --pf-v6-l-gallery--GridTemplateColumns--min: 40%;
   }
 }

--- a/src/components/Widgets/SubscriptionsWidget.tsx
+++ b/src/components/Widgets/SubscriptionsWidget.tsx
@@ -54,7 +54,7 @@ export const SubsWidget = () => {
   const isCardError = statusCardData.isError;
 
   return (
-    <div className="subscription-inventory">
+    <div className="subscription-inventory-widget">
       {isCardDataEmpty ? (
         <EmptyState
           variant={EmptyStateVariant.lg}


### PR DESCRIPTION
### Changes
- update sass prefix config to match the actual value
- update subs widget CSS selectors to ensure upcoming widget updates

This PR should ensure smooth migration when the widget backend becomes its own service. More details are in this epic: https://issues.redhat.com/browse/RHCLOUD-40474

The styling-specific changes are documented here: https://github.com/RedHatInsights/widget-layout-backend/blob/master/docs/WIDGET_MIGRATION.md

## Summary by Sourcery

Adjust SubscriptionWidget styling to be compatible with FEO-based registry by updating SASS prefix configuration and CSS selectors, renaming the root widget class, and adding container queries for responsive layout.

Enhancements:
- Update sassPrefix in fec.config.js to include .subscription-inventory-widget selector for FEO registry integration
- Rename root widget class in SubscriptionsWidget.tsx to .subscription-inventory-widget to match updated styling scope
- Refactor SubscriptionsWidget.scss to use the subscription-inventory-widget container with CSS container queries for responsive gallery grid layouts
- Extend alert and empty state styles under the new widget container scope for consistent presentation