### PR TITLE
TUSC-317 -Remove references to red hat marketplace 

### DIFF
--- a/src/components/PurchaseModal/PurchaseModal.tsx
+++ b/src/components/PurchaseModal/PurchaseModal.tsx
@@ -93,20 +93,13 @@ const PurchaseModal: FunctionComponent = () => {
           </GridItem>
           <GridItem span={6}>
             <PurchaseCard
-              body="A simpler way to buy and manage enterprise software, with automated deployment to any cloud."
-              ctaHref="https://marketplace.redhat.com"
-              ctaText="Go to the Marketplace"
-              title="Red Hat Marketplace"
-            />
-          </GridItem>
-          <GridItem span={6}>
-            <PurchaseCard
               body="Easily configure and buy Red Hat Enterprise Linux in our online store."
               ctaHref="https://www.redhat.com/store"
               ctaText="Go to the Red Hat Store"
               title="Red Hat Store"
             />
           </GridItem>
+          <GridItem span={6}></GridItem>
           <GridItem span={6}>
             <SectionHeading icon={salesIcon} title="Sales" />
           </GridItem>

--- a/src/components/PurchaseModal/__tests__/PurchaseModal.test.tsx
+++ b/src/components/PurchaseModal/__tests__/PurchaseModal.test.tsx
@@ -13,6 +13,6 @@ describe('PurchaseModal', () => {
     render(<PurchaseModal />);
 
     fireEvent.click(screen.getByText('Purchase subscriptions'));
-    expect(screen.getByText('Red Hat Marketplace')).toBeInTheDocument();
+    expect(screen.getByText('Red Hat Store')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary by Sourcery

Remove references to the Red Hat Marketplace purchase option in the PurchaseModal and update tests accordingly

Enhancements:
- Remove the Red Hat Marketplace PurchaseCard and add a placeholder grid item to maintain layout

Tests:
- Update PurchaseModal test to expect “Red Hat Store” instead of “Red Hat Marketplace”