### PR TITLE
Disable npm updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
   "tekton": {
     "enabled": true
   },
+  "npm": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "matchManagers": ["tekton"],


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove or disable the npm package-ecosystem from renovate.json to stop automatic npm updates