### PR TITLE
only run once a week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
     "enabled": true
   },
   "npm": {
-    "enabled": true
+    "enabled": true,
+    "schedule": ["* * * * 0,6"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Restrict Renovate schedule to a weekly frequency in renovate.json