### PR TITLE
TUSC-543: Use Kessel checks for authorization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@patternfly/react-core": "^6.2.0",
         "@patternfly/react-table": "^6.3.1",
         "@patternfly/react-tokens": "^6.2.2",
+        "@project-kessel/react-kessel-access-check": "^0.5.1",
         "@redhat-cloud-services/frontend-components": "^7.3.1",
         "@redhat-cloud-services/frontend-components-utilities": "^7.2.0",
         "@tanstack/react-query": "^5.0.0",
@@ -4906,6 +4907,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@project-kessel/react-kessel-access-check": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@project-kessel/react-kessel-access-check/-/react-kessel-access-check-0.5.1.tgz",
+      "integrity": "sha512-hi/z0I4ANeoxG1RYpcaNVmFus7K2bTFHsVLOleK4QojJPqmf0ZTICo8rxl6RdjFm6bWeOpSRzTL6jlRSQCSD/Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@redhat-cloud-services/eslint-config-redhat-cloud-services": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@patternfly/react-core": "^6.2.0",
     "@patternfly/react-table": "^6.3.1",
     "@patternfly/react-tokens": "^6.2.2",
+    "@project-kessel/react-kessel-access-check": "^0.5.1",
     "@redhat-cloud-services/frontend-components": "^7.3.1",
     "@redhat-cloud-services/frontend-components-utilities": "^7.2.0",
     "@tanstack/react-query": "^5.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import NotificationProvider from './contexts/NotificationProvider';
 import Notifications from './components/Notifications';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { AccessCheck } from '@project-kessel/react-kessel-access-check';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -26,12 +27,14 @@ const App = () => {
   }, []);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <NotificationProvider>
-        <Notifications />
-        <InventoryRoutes />
-      </NotificationProvider>
-    </QueryClientProvider>
+    <AccessCheck.Provider baseUrl={window.location.origin} apiPath="/api/kessel/v1beta2">
+      <QueryClientProvider client={queryClient}>
+        <NotificationProvider>
+          <Notifications />
+          <InventoryRoutes />
+        </NotificationProvider>
+      </QueryClientProvider>
+    </AccessCheck.Provider>
   );
 };
 

--- a/src/hooks/__tests__/useHasRelation.test.ts
+++ b/src/hooks/__tests__/useHasRelation.test.ts
@@ -1,0 +1,83 @@
+import { useAccessCheckContext } from '@project-kessel/react-kessel-access-check';
+import { checkSelf } from '@project-kessel/react-kessel-access-check/core/api-client';
+import { renderHook, waitFor } from '@testing-library/react';
+import { Relation, useHasRelation } from '../useHasRelation';
+import { createQueryWrapper } from '../../utilities/testHelpers';
+
+jest.mock('@project-kessel/react-kessel-access-check');
+jest.mock('@project-kessel/react-kessel-access-check/core/api-client');
+
+describe('useHasRelation hook', () => {
+  beforeEach(() => {
+    (useAccessCheckContext as jest.Mock).mockReturnValue(true);
+  });
+
+  it('returns true when access check passes', async () => {
+    (checkSelf as jest.Mock).mockReturnValue({ allowed: 'ALLOWED_TRUE' });
+
+    const { result } = renderHook(() => useHasRelation(Relation.INVENTORY_VIEW), {
+      wrapper: createQueryWrapper()
+    });
+
+    await waitFor(() => expect(result.current.has).toBe(true));
+  });
+
+  it('returns false while loading', () => {
+    (checkSelf as jest.Mock).mockReturnValue({ allowed: 'ALLOWED_TRUE' });
+
+    const { result } = renderHook(() => useHasRelation(Relation.INVENTORY_VIEW), {
+      wrapper: createQueryWrapper()
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.has).toBe(false);
+  });
+
+  it('returns false when access check fails', async () => {
+    (checkSelf as jest.Mock).mockReturnValue({ allowed: 'ALLOWED_FALSE' });
+
+    const { result } = renderHook(() => useHasRelation(Relation.INVENTORY_VIEW), {
+      wrapper: createQueryWrapper()
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.has).toBe(false));
+  });
+
+  it('returns false on query error', async () => {
+    (checkSelf as jest.Mock).mockImplementation(() => {
+      throw new Error('whoops');
+    });
+
+    const { result } = renderHook(() => useHasRelation(Relation.INVENTORY_VIEW), {
+      wrapper: createQueryWrapper()
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.has).toBe(false));
+  });
+
+  describe('unexpected response from kessel', () => {
+    it('returns false on empty object', async () => {
+      (checkSelf as jest.Mock).mockReturnValue({});
+
+      const { result } = renderHook(() => useHasRelation(Relation.INVENTORY_VIEW), {
+        wrapper: createQueryWrapper()
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.has).toBe(false));
+    });
+
+    it('returns false on unexpected allowed value', async () => {
+      (checkSelf as jest.Mock).mockReturnValue({ allowed: 'A_WEIRD_VALUE' });
+
+      const { result } = renderHook(() => useHasRelation(Relation.INVENTORY_VIEW), {
+        wrapper: createQueryWrapper()
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.has).toBe(false));
+    });
+  });
+});

--- a/src/hooks/__tests__/useUser.test.tsx
+++ b/src/hooks/__tests__/useUser.test.tsx
@@ -51,7 +51,6 @@ describe('useUser hook', () => {
 
     await waitFor(() =>
       expect(result.current.data).toEqual({
-        canReadProducts: true,
         isOrgAdmin: true
       })
     );

--- a/src/hooks/useHasRelation.ts
+++ b/src/hooks/useHasRelation.ts
@@ -1,0 +1,55 @@
+import { useAccessCheckContext } from '@project-kessel/react-kessel-access-check';
+import { checkSelf } from '@project-kessel/react-kessel-access-check/core/api-client';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useQuery } from '@tanstack/react-query';
+
+// 5 minutes * 60 seconds * 1000 milliseconds
+const QUERY_STALE_TIME = 5 * 60 * 1000;
+
+export enum Relation {
+  INVENTORY_VIEW = 'subscriptions_product_view',
+  INVENTORY_EDIT = 'subscriptions_product_edit'
+}
+
+interface HasRelationResult {
+  has: boolean;
+  isLoading: boolean;
+}
+
+/**
+ * useHasRelation checks if the current user has a given relation on the default workspace
+ */
+export const useHasRelation = (relation: Relation): HasRelationResult => {
+  const accessCheckContext = useAccessCheckContext();
+  const chrome = useChrome();
+
+  const { data: has, isLoading: accessCheckIsLoading } = useQuery({
+    queryKey: ['kessel', relation],
+    queryFn: async () => {
+      const user = await chrome.auth.getUser();
+
+      if (!user) {
+        throw new Error('user does not exist');
+      }
+
+      return (
+        (
+          await checkSelf(accessCheckContext, {
+            relation,
+            resource: {
+              id: `redhat/${user.identity.org_id}`,
+              type: 'tenant',
+              reporter: { type: 'rbac' }
+            }
+          })
+        ).allowed === 'ALLOWED_TRUE'
+      );
+    },
+    staleTime: QUERY_STALE_TIME
+  });
+
+  return {
+    has: !!has,
+    isLoading: accessCheckIsLoading
+  };
+};

--- a/src/hooks/useHasRelation.ts
+++ b/src/hooks/useHasRelation.ts
@@ -17,7 +17,7 @@ interface HasRelationResult {
 }
 
 /**
- * useHasRelation checks if the current user has a given relation on the default workspace
+ * useHasRelation checks if the current user has a given relation on their org
  */
 export const useHasRelation = (relation: Relation): HasRelationResult => {
   const accessCheckContext = useAccessCheckContext();

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,10 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import { authenticateUser, getUserRbacPermissions } from '../utilities/platformServices';
+import { authenticateUser } from '../utilities/platformServices';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 interface User {
   accountNumber: string;
-  canReadProducts: boolean;
   isOrgAdmin: boolean;
 }
 
@@ -15,13 +14,8 @@ const useUser = () => {
     queryKey: ['user'],
     queryFn: async () => {
       const userStatus = await authenticateUser(chrome);
-      const rawRbacPermissions = await getUserRbacPermissions(chrome);
-      const rbacPermissions = rawRbacPermissions.map((rawPermission) => rawPermission.permission);
       const user: User = {
         accountNumber: userStatus.identity.account_number,
-        canReadProducts:
-          rbacPermissions.includes('subscriptions:products:read') ||
-          rbacPermissions.includes('subscriptions:*:*'),
         isOrgAdmin: userStatus.identity.user.is_org_admin === true
       };
       return user;

--- a/src/pages/DetailsPage/DetailsPage.tsx
+++ b/src/pages/DetailsPage/DetailsPage.tsx
@@ -12,8 +12,6 @@ import { Processing } from '../../components/emptyState';
 import useSingleProduct from '../../hooks/useSingleProduct';
 import Unavailable from '@redhat-cloud-services/frontend-components/Unavailable';
 import NotFound from '../NotFoundPage/NotFound';
-import { useQueryClient } from '@tanstack/react-query';
-import { User } from '../../hooks/useUser';
 import SubscriptionTable from '../../components/SubscriptionTable';
 import { HttpError } from '../../utilities/errors';
 import Section from '@redhat-cloud-services/frontend-components/Section';
@@ -21,87 +19,95 @@ import { Popover } from '@patternfly/react-core/dist/dynamic/components/Popover'
 import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 import ExternalLink from '../../components/ExternalLink';
 import NoPermissionsPage from '../NoPermissionsPage';
+import { Relation, useHasRelation } from '../../hooks/useHasRelation';
 
 const DetailsPage: FunctionComponent = () => {
   const { SKU } = useParams<{ SKU: string }>();
 
-  const queryClient = useQueryClient();
-  const user: User = queryClient.getQueryData(['user']);
   const { isLoading, error, data } = useSingleProduct(SKU);
   const missingText = 'Not Available';
   const docsLink =
     'https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-config-vm-sub_';
 
-  if (!user?.canReadProducts) {
+  const { has: canReadProducts, isLoading: canReadProductsIsLoading } = useHasRelation(
+    Relation.INVENTORY_VIEW
+  );
+
+  if (!canReadProducts && !canReadProductsIsLoading) {
     return <NoPermissionsPage />;
   }
 
   const Page: FunctionComponent = () => (
     <>
-      <PageHeader>
-        {isLoading && !error && <Processing />}
+      {canReadProductsIsLoading && <Processing />}
+      {!canReadProductsIsLoading && (
+        <PageHeader>
+          {isLoading && !error && <Processing />}
 
-        {!isLoading && !error && (
-          <>
-            <Breadcrumb>
-              <BreadcrumbItem render={() => <Link to="../">Subscriptions Inventory</Link>} />
-              <BreadcrumbItem isActive>{data.name} </BreadcrumbItem>
-            </Breadcrumb>
-            <PageHeaderTitle title={data.name} />
-            <List isPlain>
-              <ListItem className="pf-v6-u-mt-md">
-                <b>SKU: </b>
-                {data.sku || missingText}
-              </ListItem>
-              <ListItem className="pf-v6-u-mt-0">
-                <b>Quantity: </b>
-                {data.quantity ?? missingText}
-              </ListItem>
-              <ListItem className="pf-v6-u-mt-0">
-                <b>Support level: </b>
-                {data.serviceLevel || missingText}
-              </ListItem>
-              <ListItem className="pf-v6-u-mt-0">
-                <b>Support type: </b>
-                {data.serviceType || missingText}
-              </ListItem>
-              <ListItem className="pf-v6-u-mt-0">
-                <b>Capacity: </b>
-                {data.capacity ? (
-                  <>
-                    {data.capacity.name} <Badge isRead>{data.capacity.quantity}</Badge>
-                  </>
-                ) : (
-                  <>Not Available</>
-                )}
-              </ListItem>
-              <ListItem className="pf-v6-u-mt-0">
-                <b>
-                  Virtual Guest Limit{' '}
-                  <Popover
-                    aria-label="Learn more about Virtual Guest Limit"
-                    bodyContent={
-                      <p>
-                        The maximum number of virtual machines that can run on a system at no
-                        additional cost if the system using this subscription is deployed as a
-                        hypervisor to host virtual machines. When this field displays a non-zero
-                        value, usage of the virt-who utility is required for proper subscription
-                        reporting. Learn more about working with virtual machines and
-                        hypervisor-based subscriptions.{' '}
-                        <ExternalLink href={docsLink}> </ExternalLink>
-                      </p>
-                    }
-                  >
-                    <QuestionCircleIcon onClick={(e) => e.stopPropagation()} />
-                  </Popover>
-                  :{' '}
-                </b>
-                {data.virtLimit != undefined && data.virtLimit != '' ? data.virtLimit : missingText}
-              </ListItem>
-            </List>
-          </>
-        )}
-      </PageHeader>
+          {!isLoading && !error && (
+            <>
+              <Breadcrumb>
+                <BreadcrumbItem render={() => <Link to="../">Subscriptions Inventory</Link>} />
+                <BreadcrumbItem isActive>{data.name} </BreadcrumbItem>
+              </Breadcrumb>
+              <PageHeaderTitle title={data.name} />
+              <List isPlain>
+                <ListItem className="pf-v6-u-mt-md">
+                  <b>SKU: </b>
+                  {data.sku || missingText}
+                </ListItem>
+                <ListItem className="pf-v6-u-mt-0">
+                  <b>Quantity: </b>
+                  {data.quantity ?? missingText}
+                </ListItem>
+                <ListItem className="pf-v6-u-mt-0">
+                  <b>Support level: </b>
+                  {data.serviceLevel || missingText}
+                </ListItem>
+                <ListItem className="pf-v6-u-mt-0">
+                  <b>Support type: </b>
+                  {data.serviceType || missingText}
+                </ListItem>
+                <ListItem className="pf-v6-u-mt-0">
+                  <b>Capacity: </b>
+                  {data.capacity ? (
+                    <>
+                      {data.capacity.name} <Badge isRead>{data.capacity.quantity}</Badge>
+                    </>
+                  ) : (
+                    <>Not Available</>
+                  )}
+                </ListItem>
+                <ListItem className="pf-v6-u-mt-0">
+                  <b>
+                    Virtual Guest Limit{' '}
+                    <Popover
+                      aria-label="Learn more about Virtual Guest Limit"
+                      bodyContent={
+                        <p>
+                          The maximum number of virtual machines that can run on a system at no
+                          additional cost if the system using this subscription is deployed as a
+                          hypervisor to host virtual machines. When this field displays a non-zero
+                          value, usage of the virt-who utility is required for proper subscription
+                          reporting. Learn more about working with virtual machines and
+                          hypervisor-based subscriptions.{' '}
+                          <ExternalLink href={docsLink}> </ExternalLink>
+                        </p>
+                      }
+                    >
+                      <QuestionCircleIcon onClick={(e) => e.stopPropagation()} />
+                    </Popover>
+                    :{' '}
+                  </b>
+                  {data.virtLimit != undefined && data.virtLimit != ''
+                    ? data.virtLimit
+                    : missingText}
+                </ListItem>
+              </List>
+            </>
+          )}
+        </PageHeader>
+      )}
       {!error && (
         <Section>
           <PageSection variant="default">

--- a/src/pages/DetailsPage/__tests__/DetailsPage.test.tsx
+++ b/src/pages/DetailsPage/__tests__/DetailsPage.test.tsx
@@ -7,8 +7,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import useUser from '../../../hooks/useUser';
 import useSingleProduct from '../../../hooks/useSingleProduct';
 import { Product } from '../../../hooks/useProducts';
+import { useHasRelation } from '../../../hooks/useHasRelation';
 
 jest.mock('../../../hooks/useUser');
+jest.mock('../../../hooks/useHasRelation');
 jest.mock('../../../hooks/useSingleProduct');
 jest.mock('react-router-dom', () => ({
   ...(jest.requireActual('react-router-dom') as Record<string, unknown>),
@@ -32,25 +34,26 @@ const Page = () => (
   </QueryClientProvider>
 );
 
-const mockAuthenticateUser = (
-  isLoading: boolean,
-  orgAdminStatus: boolean,
-  canReadProducts: boolean
-) => {
+const mockKesselCheck = (canReadProducts: boolean) => {
+  (useHasRelation as jest.Mock).mockReturnValue({
+    isLoading: false,
+    has: canReadProducts
+  });
+};
+
+const mockAuthenticateUser = (isLoading: boolean, orgAdminStatus: boolean) => {
   (useUser as jest.Mock).mockReturnValue({
     isLoading: isLoading,
     isFetching: false,
     isSuccess: true,
     isError: false,
     data: {
-      isOrgAdmin: orgAdminStatus,
-      canReadProducts
+      isOrgAdmin: orgAdminStatus
     }
   });
 
   queryClient.setQueryData(['user'], {
-    isOrgAdmin: orgAdminStatus,
-    canReadProducts
+    isOrgAdmin: orgAdminStatus
   });
 };
 
@@ -93,7 +96,8 @@ describe('Details Page', () => {
   it('loader shows correctly', async () => {
     const isLoading = true;
     const isOrgAdmin = true;
-    mockAuthenticateUser(isLoading, isOrgAdmin, true);
+    mockKesselCheck(true);
+    mockAuthenticateUser(isLoading, isOrgAdmin);
     const container = render(<Page />);
     expect(container).toHaveLoader();
   });
@@ -102,8 +106,8 @@ describe('Details Page', () => {
 it('renders data', async () => {
   const isLoading = false;
   const isOrgAdmin = true;
-  const canReadProducts = true;
-  mockAuthenticateUser(isLoading, isOrgAdmin, canReadProducts);
+  mockKesselCheck(true);
+  mockAuthenticateUser(isLoading, isOrgAdmin);
   mockSingleProduct(true);
 
   const { getAllByText } = render(<Page />);
@@ -115,8 +119,8 @@ it('renders data', async () => {
 it("redirects when can't read products", async () => {
   const isLoading = false;
   const isOrgAdmin = true;
-  const canReadProducts = false;
-  mockAuthenticateUser(isLoading, isOrgAdmin, canReadProducts);
+  mockKesselCheck(false);
+  mockAuthenticateUser(isLoading, isOrgAdmin);
   mockSingleProduct(false);
   render(<Page />);
   waitFor(() => expect(screen.getByAltText('no-permissions')).toBeInTheDocument());
@@ -125,10 +129,10 @@ it("redirects when can't read products", async () => {
 it('renders not available for missing data', async () => {
   const isLoading = false;
   const isOrgAdmin = true;
-  const canReadProducts = true;
 
-  mockAuthenticateUser(isLoading, isOrgAdmin, canReadProducts);
+  mockAuthenticateUser(isLoading, isOrgAdmin);
   mockSingleProduct(false);
+  mockKesselCheck(true);
   render(<Page />);
   expect(document.querySelector('.pf-v6-c-list').firstChild.textContent).toContain('Not Available');
 });

--- a/src/pages/SubscriptionInventoryPage/SubscriptionInventoryPage.tsx
+++ b/src/pages/SubscriptionInventoryPage/SubscriptionInventoryPage.tsx
@@ -19,13 +19,18 @@ import { Stack } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
 import { StackItem } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
 import StatusCountCards from '../../components/StatusCountCards';
 import NoPermissionsPage from '../NoPermissionsPage';
+import { Relation, useHasRelation } from '../../hooks/useHasRelation';
 const SubscriptionInventoryPage: FunctionComponent = () => {
   const queryClient = useQueryClient();
   const user: User = queryClient.getQueryData(['user']);
   const [searchParams, setSearchParams] = useSearchParams();
   const [filter, setFilter] = useState<string>(() => searchParams.get('status') || '');
 
-  if (!user?.canReadProducts) {
+  const { has: canReadProducts, isLoading: canReadIsLoading } = useHasRelation(
+    Relation.INVENTORY_VIEW
+  );
+
+  if (!canReadProducts && !canReadIsLoading) {
     return <NoPermissionsPage />;
   }
 
@@ -45,55 +50,60 @@ const SubscriptionInventoryPage: FunctionComponent = () => {
 
   return (
     <>
-      <PageHeader>
-        <Split hasGutter>
-          <SplitItem isFilled>
-            <PageHeaderTitle title="Subscriptions Inventory" />
-          </SplitItem>
-          <SplitItem>
-            <PurchaseModal />
-          </SplitItem>
-        </Split>
-      </PageHeader>
-      <PageSection>
-        <Stack hasGutter>
-          <StackItem>
-            <GettingStartedCard />
-          </StackItem>
-          {!statusCardData.error && !productData.error && (
-            <>
+      {canReadIsLoading && <Processing />}
+      {!canReadIsLoading && (
+        <>
+          <PageHeader>
+            <Split hasGutter>
+              <SplitItem isFilled>
+                <PageHeaderTitle title="Subscriptions Inventory" />
+              </SplitItem>
+              <SplitItem>
+                <PurchaseModal />
+              </SplitItem>
+            </Split>
+          </PageHeader>
+          <PageSection>
+            <Stack hasGutter>
               <StackItem>
-                {statusCardData.isLoading && <Processing />}
-                {!statusCardData.isLoading && (
-                  <StatusCountCards
-                    statusCardData={statusCardData.data}
-                    statusIsFetching={statusCardData.isFetching}
-                    setFilter={updateFilter}
-                    filter={filter}
-                  />
-                )}
+                <GettingStartedCard />
               </StackItem>
-              <StackItem>
-                <Title headingLevel="h2" className="pf-v5-u-mb-md">
-                  Subscriptions for account {user.accountNumber}
-                </Title>
-              </StackItem>
-              <StackItem>
-                {productData.isLoading && <Processing />}
-                {!productData.isLoading && (
-                  <ProductsTable
-                    data={productData.data}
-                    isFetching={productData.isFetching}
-                    filter={filter}
-                    setFilter={updateFilter}
-                  />
-                )}
-              </StackItem>
-            </>
-          )}
-          {(statusCardData.error || productData.error) && <Unavailable />}
-        </Stack>
-      </PageSection>
+              {!statusCardData.error && !productData.error && (
+                <>
+                  <StackItem>
+                    {statusCardData.isLoading && <Processing />}
+                    {!statusCardData.isLoading && (
+                      <StatusCountCards
+                        statusCardData={statusCardData.data}
+                        statusIsFetching={statusCardData.isFetching}
+                        setFilter={updateFilter}
+                        filter={filter}
+                      />
+                    )}
+                  </StackItem>
+                  <StackItem>
+                    <Title headingLevel="h2" className="pf-v5-u-mb-md">
+                      Subscriptions for account {user.accountNumber}
+                    </Title>
+                  </StackItem>
+                  <StackItem>
+                    {productData.isLoading && <Processing />}
+                    {!productData.isLoading && (
+                      <ProductsTable
+                        data={productData.data}
+                        isFetching={productData.isFetching}
+                        filter={filter}
+                        setFilter={updateFilter}
+                      />
+                    )}
+                  </StackItem>
+                </>
+              )}
+              {(statusCardData.error || productData.error) && <Unavailable />}
+            </Stack>
+          </PageSection>
+        </>
+      )}
     </>
   );
 };

--- a/src/pages/SubscriptionInventoryPage/__tests__/SubscriptionInventoryPage.test.tsx
+++ b/src/pages/SubscriptionInventoryPage/__tests__/SubscriptionInventoryPage.test.tsx
@@ -8,8 +8,10 @@ import useUser from '../../../hooks/useUser';
 import useProducts from '../../../hooks/useProducts';
 import useStatus from '../../../hooks/useStatus';
 import { def, get } from 'bdd-lazy-var';
+import { useHasRelation } from '../../../hooks/useHasRelation';
 
 jest.mock('../../../hooks/useUser');
+jest.mock('../../../hooks/useHasRelation');
 jest.mock('../../../hooks/useProducts');
 jest.mock('../../../hooks/useStatus');
 jest.mock('react-router-dom', () => ({
@@ -31,14 +33,16 @@ const PageContainer = () => (
   </QueryClientProvider>
 );
 
-const mockAuthenticateUser = (
-  orgAdminStatus: boolean,
-  isError: boolean,
-  canReadProducts: boolean
-) => {
+const mockKesselCheck = (canReadProducts: boolean) => {
+  (useHasRelation as jest.Mock).mockReturnValue({
+    isLoading: false,
+    has: canReadProducts
+  });
+};
+
+const mockAuthenticateUser = (orgAdminStatus: boolean, isError: boolean) => {
   const user = {
     accountNumber: '8675309',
-    canReadProducts: canReadProducts,
     isOrgAdmin: orgAdminStatus
   };
   (useUser as jest.Mock).mockReturnValue({
@@ -77,7 +81,8 @@ describe('SubscriptionInventoryPage', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    mockAuthenticateUser(get('orgAdmin'), get('userError'), get('canReadProducts'));
+    mockKesselCheck(get('canReadProducts'));
+    mockAuthenticateUser(get('orgAdmin'), get('userError'));
     (useProducts as jest.Mock).mockReturnValue({
       isLoading: get('productsLoading'),
       error: get('productsError'),


### PR DESCRIPTION
This removes all deprecated v1 access checks from subscription inventory and replaces them with calls to Kessel via the `useHasRelation` hook.

It also replaces implicit access grants (edit implies read) with strict checks for _VIEW permissions

Unit tests are updated as well

## Summary by Sourcery

Replace legacy subscription inventory RBAC checks with Kessel-based authorization and adjust UI loading/permission flows accordingly.

New Features:
- Introduce a generic useHasRelation hook backed by Kessel to check user relations such as subscriptions inventory view/edit.

Enhancements:
- Wire subscription inventory and product details pages to use Kessel relation checks for INVENTORY_VIEW access instead of user.canReadProducts.
- Wrap the app in Kessel AccessCheck.Provider to configure the base API endpoint for authorization checks.
- Simplify the useUser hook to only fetch core user identity/org-admin status and not RBAC permissions.

Build:
- Add @project-kessel/react-kessel-access-check dependency for Kessel-based authorization.

Tests:
- Update subscription inventory and details page tests to mock Kessel relation checks instead of legacy RBAC flags.
- Adjust useUser hook tests to reflect removal of canReadProducts from the user shape.